### PR TITLE
feat: add RTSP input support with safe live-source routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## Unreleased
-
 ## 0.2.0
+
+## Unreleased
 
 - Unified `predict(...)` and `track(...)` around a single broad input surface with specialized internal routing for paths, arrays, raw tensors, prepared CUDA tensors, and live sources.
 - Added `PreparedTensorInput`, a prepared CUDA-tensor fast path, and a `benchmark` CLI for comparing host-image and CUDA-tensor inference through the native TensorRT runtime.
@@ -10,6 +10,7 @@
 - Fixed prepared-tensor correctness issues around integer dtype validation, CUDA producer-stream handoff, and cross-stream prepared-tensor inference.
 - Fixed unit-range float preprocessing so non-square padded inputs keep the correct scale instead of being divided by `255` a second time.
 - Expanded runtime and unit coverage for unified routing, benchmark CLI help, tracker-session input handling, and prepared-tensor regressions.
+- Added first-class RTSP input support so plain `rtsp://...` and `rtsps://...` sources can be used without writing a custom GStreamer pipeline.
 
 ## 0.1.3
 

--- a/README.md
+++ b/README.md
@@ -165,6 +165,12 @@ Launch the GUI against a synthetic GStreamer source when no camera is attached:
 yoloe-camera-gui --source videotest://ball
 ```
 
+Launch the GUI against an RTSP stream:
+
+```bash
+yoloe-camera-gui --source rtsp://user:pass@camera.local:554/stream
+```
+
 Repo-local convenience launcher:
 
 ```bash
@@ -203,6 +209,7 @@ GitHub Actions is the supported automation path for this repository.
 - Plain file paths, PIL images, NumPy arrays, CPU tensors, and CUDA tensors are still accepted without requiring manual preprocessing.
 - For production deployments, prefer `YOLOEEngine.from_engine(...)` and prebuilt bundles over `from_pt(...)`.
 - Live USB camera input is available through a GStreamer appsink pipeline. Jetson zero-copy camera ingest is still on the roadmap.
+- Direct RTSP URLs such as `rtsp://camera.local/stream` are supported and resolved to a GStreamer RTSP pipeline automatically.
 - If you do not have a camera attached, use `videotest://<pattern>` such as `videotest://ball` or `videotest://smpte`.
 
 ## Repository Layout

--- a/docs/camera-gui.md
+++ b/docs/camera-gui.md
@@ -31,6 +31,7 @@ track IDs when detections are matched across frames.
 ## Source handling
 
 - `/dev/video*` device paths are wrapped in the package's GStreamer USB camera pipeline
+- `rtsp://...` and `rtsps://...` URLs are wrapped in a package-managed GStreamer RTSP pipeline
 - raw GStreamer pipeline strings are also accepted
 - `videotest://<pattern>` creates a synthetic GStreamer source, for example `videotest://ball` or `videotest://smpte`
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -68,6 +68,12 @@ print(first.boxes.id, second.boxes.id)
 yoloe-camera-gui
 ```
 
+Direct RTSP input is also supported:
+
+```bash
+yoloe-camera-gui --source rtsp://user:pass@camera.local:554/stream
+```
+
 The GUI lets you change:
 
 - the video source

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,8 +42,8 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         default=DEFAULT_CAMERA_SOURCE,
         help="Camera source for live GUI/integration tests. "
         "Defaults to /dev/video0 when present, otherwise videotest://ball. "
-        "Device paths are wrapped in a USB-camera GStreamer pipeline; raw GStreamer pipelines and dummy aliases "
-        "like videotest://ball are also accepted.",
+        "Device paths are wrapped in a USB-camera GStreamer pipeline; RTSP URLs, raw GStreamer pipelines, and "
+        "dummy aliases like videotest://ball are also accepted.",
     )
     group.addoption(
         "--camera-labels",

--- a/tests/test_gstreamer.py
+++ b/tests/test_gstreamer.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
-from yoloe_tensorrt import build_dummy_video_pipeline, build_usb_camera_pipeline, camera_source_from_spec
+from yoloe_tensorrt import (
+    build_dummy_video_pipeline,
+    build_rtsp_pipeline,
+    build_usb_camera_pipeline,
+    camera_source_from_spec,
+)
 
 
 def test_build_usb_camera_pipeline_defaults_to_mjpeg_bgr_appsink() -> None:
@@ -36,6 +41,31 @@ def test_build_dummy_video_pipeline_uses_videotestsrc_bgr_appsink() -> None:
     assert "appsink name=sink" in pipeline
 
 
+def test_build_rtsp_pipeline_uses_uridecodebin_bgr_appsink() -> None:
+    pipeline = build_rtsp_pipeline("rtsp://camera.local:554/stream", width=1280, height=720, fps=15)
+
+    assert 'uridecodebin uri="rtsp://camera.local:554/stream" use-buffering=false' in pipeline
+    assert "queue max-size-buffers=1" in pipeline
+    assert "autovideoconvert" in pipeline
+    assert "video/x-raw !" in pipeline
+    assert "videoconvert" in pipeline
+    assert "videoscale" in pipeline
+    assert "videorate" in pipeline
+    assert "video/x-raw,format=BGR,width=1280,height=720,framerate=15/1" in pipeline
+    assert "appsink name=sink" in pipeline
+
+
+def test_build_rtsp_pipeline_preserves_credentials_and_query() -> None:
+    uri = "rtsp://user:pass@example.com:8554/stream?profile=main&channel=1"
+    pipeline = build_rtsp_pipeline(uri, width=None, height=None, fps=None)
+
+    assert f'uridecodebin uri="{uri}"' in pipeline
+    assert "autovideoconvert" in pipeline
+    assert "videoscale" not in pipeline
+    assert "videorate" not in pipeline
+    assert "video/x-raw,format=BGR" in pipeline
+
+
 def test_camera_source_from_spec_supports_dummy_alias() -> None:
     source = camera_source_from_spec(
         "videotest://zone-plate",
@@ -51,3 +81,54 @@ def test_camera_source_from_spec_supports_dummy_alias() -> None:
     assert "videotestsrc" in source.pipeline
     assert "pattern=zone-plate" in source.pipeline
     assert "width=320,height=240,framerate=15/1" in source.pipeline
+
+
+def test_camera_source_from_spec_supports_rtsp_uri() -> None:
+    source = camera_source_from_spec(
+        "rtsp://camera.local/stream",
+        width=800,
+        height=450,
+        fps=20,
+        prefix="rtspcam",
+        max_frames=2,
+    )
+
+    assert source.prefix == "rtspcam"
+    assert source.max_frames == 2
+    assert 'uridecodebin uri="rtsp://camera.local/stream"' in source.pipeline
+    assert "video/x-raw,format=BGR,width=800,height=450,framerate=20/1" in source.pipeline
+
+
+def test_camera_source_from_spec_preserves_rtsp_native_caps_when_unspecified() -> None:
+    source = camera_source_from_spec(
+        "rtsp://camera.local/stream",
+        prefix="rtspnative",
+    )
+
+    assert source.prefix == "rtspnative"
+    assert 'uridecodebin uri="rtsp://camera.local/stream"' in source.pipeline
+    assert "videoscale" not in source.pipeline
+    assert "videorate" not in source.pipeline
+    assert "video/x-raw,format=BGR" in source.pipeline
+
+
+def test_camera_source_from_spec_prioritizes_rtsp_uri_over_bang_character() -> None:
+    uri = "rtsp://user:pa!ss@camera.local:8554/stream?profile=main&flag=1"
+
+    source = camera_source_from_spec(uri, prefix="rtspbang")
+
+    assert source.prefix == "rtspbang"
+    assert source.pipeline != uri
+    assert f'uridecodebin uri="{uri}"' in source.pipeline
+
+
+def test_camera_source_from_spec_keeps_explicit_rtspsrc_pipeline_literal() -> None:
+    pipeline = (
+        'rtspsrc location="rtsp://camera.local/stream" latency=0 ! '
+        "rtph264depay ! h264parse ! avdec_h264 ! videoconvert ! appsink name=sink"
+    )
+
+    source = camera_source_from_spec(pipeline, prefix="manual")
+
+    assert source.prefix == "manual"
+    assert source.pipeline == pipeline

--- a/tests/test_inputs.py
+++ b/tests/test_inputs.py
@@ -1,11 +1,19 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import numpy as np
 import pytest
 import torch
-from yoloe_tensorrt.inputs import PreparedTensorInput, normalize_inference_source, validate_prepared_tensor
+from yoloe_tensorrt.engine import YOLOEEngine
+from yoloe_tensorrt.inputs import (
+    PreparedTensorInput,
+    iter_inference_sources,
+    normalize_inference_source,
+    validate_prepared_tensor,
+)
 from yoloe_tensorrt.preprocess import preprocess_image
-from yoloe_tensorrt.source import SourceItem
+from yoloe_tensorrt.source import SourceItem, SourceStream
 
 
 def test_prepared_tensor_input_supports_legacy_unpacking() -> None:
@@ -46,6 +54,11 @@ def test_prepared_input_hint_rejects_cuda_false() -> None:
         normalize_inference_source(tensor, cuda=False, input_hint="prepared")
 
 
+def test_normalize_inference_source_rejects_rtsp_urls() -> None:
+    with pytest.raises(ValueError, match="Live sources require stream=True"):
+        normalize_inference_source("rtsp://camera.local/stream")
+
+
 def test_validate_prepared_tensor_rejects_integer_dtype() -> None:
     tensor = torch.zeros((1, 3, 8, 8), dtype=torch.uint8)
 
@@ -82,3 +95,114 @@ def test_preprocess_image_preserves_unit_range_float_inputs_with_padding() -> No
     assert sample.tensor.dtype == torch.float32
     assert float(sample.tensor[0, 0, 8, 8].item()) == pytest.approx(0.5, abs=1e-5)
     assert float(sample.tensor[0, 0, 0, 0].item()) == pytest.approx(114.0 / 255.0, abs=1e-5)
+
+
+def test_iter_inference_sources_routes_rtsp_urls_to_gstreamer_source(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _FakeRtspSource(SourceStream):
+        is_live_source = True
+        max_frames = 1
+
+        def __iter__(self):
+            yield SourceItem(image=np.zeros((4, 4, 3), dtype=np.uint8), path="rtsp_frame000000")
+
+    captured: dict[str, object] = {}
+
+    def _fake_camera_source_from_spec(source_value: object, **kwargs) -> SourceStream:
+        captured["source_value"] = source_value
+        captured.update(kwargs)
+        return _FakeRtspSource()
+
+    monkeypatch.setattr("yoloe_tensorrt.inputs.camera_source_from_spec", _fake_camera_source_from_spec)
+    items = list(iter_inference_sources("rtsp://camera.local/stream"))
+
+    assert len(items) == 1
+    assert isinstance(items[0], SourceItem)
+    assert captured["source_value"] == "rtsp://camera.local/stream"
+    assert captured["prefix"] == "rtsp"
+    assert captured["width"] is None
+    assert captured["height"] is None
+    assert captured["fps"] is None
+
+
+@pytest.mark.parametrize("method_name", ["predict", "track"])
+def test_engine_rejects_rtsp_urls_without_stream(method_name: str) -> None:
+    engine = object.__new__(YOLOEEngine)
+    engine.metadata = SimpleNamespace(default_imgsz=(640, 640), max_det=100)
+    engine._prompt_generation = 0
+
+    method = getattr(engine, method_name)
+    with pytest.raises(ValueError, match="Live sources require stream=True"):
+        method("rtsp://camera.local/stream")
+
+
+@pytest.mark.parametrize("method_name", ["predict", "track"])
+def test_engine_rejects_iterable_rtsp_urls_without_stream(method_name: str) -> None:
+    engine = object.__new__(YOLOEEngine)
+    engine.metadata = SimpleNamespace(default_imgsz=(640, 640), max_det=100)
+    engine._prompt_generation = 0
+
+    method = getattr(engine, method_name)
+    with pytest.raises(ValueError, match="Live sources require stream=True"):
+        method(["rtsp://camera.local/stream"])
+
+
+@pytest.mark.parametrize("method_name", ["predict", "track"])
+def test_engine_rejects_generator_rtsp_urls_without_stream(method_name: str) -> None:
+    engine = object.__new__(YOLOEEngine)
+    engine.metadata = SimpleNamespace(default_imgsz=(640, 640), max_det=100)
+    engine._prompt_generation = 0
+
+    def _source():
+        yield "rtsp://camera.local/stream"
+
+    method = getattr(engine, method_name)
+    with pytest.raises(ValueError, match="Live sources require stream=True"):
+        method(_source())
+
+
+@pytest.mark.parametrize(
+    ("method_name", "iter_attr"),
+    [("predict", "_predict_iter"), ("track", "_track_iter")],
+)
+def test_engine_does_not_eagerly_materialize_iterable_sources(
+    method_name: str,
+    iter_attr: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    engine = object.__new__(YOLOEEngine)
+    engine.metadata = SimpleNamespace(default_imgsz=(640, 640), max_det=100)
+    consumed = {"count": 0}
+
+    def _source():
+        consumed["count"] += 1
+        yield PreparedTensorInput(
+            tensor=torch.zeros((1, 3, 8, 8), dtype=torch.float32),
+            path="tensor0",
+        )
+
+    def _fake_iter(*args, **kwargs):
+        yield "sentinel"
+
+    monkeypatch.setattr(engine, iter_attr, _fake_iter)
+    method = getattr(engine, method_name)
+
+    results = method(_source())
+
+    assert len(results) == 1
+    assert results[0] == "sentinel"
+    assert consumed["count"] == 0
+
+
+def test_iter_inference_sources_allows_finite_live_sources_when_unbounded_live_disabled() -> None:
+    class _FiniteLiveSource(SourceStream):
+        is_live_source = True
+        max_frames = 1
+
+        def __iter__(self):
+            yield SourceItem(image=np.zeros((4, 4, 3), dtype=np.uint8), path="frame0")
+
+    items = list(iter_inference_sources([_FiniteLiveSource()], allow_unbounded_live=False))
+
+    assert len(items) == 1
+    assert isinstance(items[0], SourceItem)
+    assert items[0].path == "frame0"

--- a/yoloe_tensorrt/__init__.py
+++ b/yoloe_tensorrt/__init__.py
@@ -9,6 +9,7 @@ __all__ = [
     "configure_logging",
     "GStreamerSource",
     "build_usb_camera_pipeline",
+    "build_rtsp_pipeline",
     "build_dummy_video_pipeline",
     "camera_source_from_spec",
     "run_camera_gui",
@@ -46,6 +47,10 @@ def __getattr__(name: str):
         from .gstreamer import build_usb_camera_pipeline
 
         return build_usb_camera_pipeline
+    if name == "build_rtsp_pipeline":
+        from .gstreamer import build_rtsp_pipeline
+
+        return build_rtsp_pipeline
     if name == "build_dummy_video_pipeline":
         from .gstreamer import build_dummy_video_pipeline
 

--- a/yoloe_tensorrt/engine.py
+++ b/yoloe_tensorrt/engine.py
@@ -14,7 +14,12 @@ from ultralytics.utils import nms, ops
 from .artifacts import ArtifactMetadata, default_artifact_dir, load_metadata, resolve_artifact_file
 from .assets import text_asset_search_roots
 from .export import export_model
-from .inputs import InferenceSourceItem, PreparedTensorInput, iter_inference_sources, validate_prepared_tensor
+from .inputs import (
+    InferenceSourceItem,
+    PreparedTensorInput,
+    iter_inference_sources,
+    validate_prepared_tensor,
+)
 from .logging_utils import get_logger
 from .native_backend import build_native_main_runtime
 from .preprocess import normalize_imgsz, preprocess_image
@@ -26,7 +31,7 @@ from .prompts import (
     load_prompt_projector,
     resolve_text_asset_path,
 )
-from .source import SourceItem, is_finite_live_source, is_live_source, normalize_source
+from .source import SourceItem, normalize_source
 from .tracking import DEFAULT_TRACKER, YOLOETrackerSession
 from .trt import TensorRTRuntime
 
@@ -657,12 +662,14 @@ class YOLOEEngine:
         input_hint: str | None,
         original_image: SourceItem | object | None,
         path: str | None,
+        allow_unbounded_live: bool = True,
     ) -> Iterator[Results]:
         for item in iter_inference_sources(
             source,
             default_prefix="frame",
             input_hint=input_hint,
             cuda=cuda,
+            allow_unbounded_live=allow_unbounded_live,
             original_image=original_image,
             path=path,
         ):
@@ -703,6 +710,7 @@ class YOLOEEngine:
         input_hint: str | None,
         original_image: SourceItem | object | None,
         path: str | None,
+        allow_unbounded_live: bool = True,
     ) -> Iterator[Results]:
         session = self.create_tracker(
             tracker=tracker,
@@ -714,6 +722,7 @@ class YOLOEEngine:
             default_prefix="frame",
             input_hint=input_hint,
             cuda=cuda,
+            allow_unbounded_live=allow_unbounded_live,
             original_image=original_image,
             path=path,
         ):
@@ -742,8 +751,6 @@ class YOLOEEngine:
     ) -> list[Results] | Iterator[Results]:
         target_size = normalize_imgsz(imgsz or self.metadata.default_imgsz)
         resolved_max_det = int(max_det or self.metadata.max_det)
-        if is_live_source(source) and not stream and not is_finite_live_source(source):
-            raise ValueError("Live sources require stream=True or an explicit max_frames limit")
         LOGGER.debug(
             "Starting predict(stream=%s, imgsz=%s, conf=%.3f, iou=%.3f, max_det=%d)",
             stream,
@@ -763,6 +770,7 @@ class YOLOEEngine:
             input_hint=input_hint,
             original_image=original_image,
             path=path,
+            allow_unbounded_live=stream,
         )
         if stream:
             return results
@@ -787,8 +795,6 @@ class YOLOEEngine:
     ) -> list[Results] | Iterator[Results]:
         target_size = normalize_imgsz(imgsz or self.metadata.default_imgsz)
         resolved_max_det = int(max_det or self.metadata.max_det)
-        if is_live_source(source) and not stream and not is_finite_live_source(source):
-            raise ValueError("Live sources require stream=True or an explicit max_frames limit")
         LOGGER.debug(
             "Starting track(stream=%s, imgsz=%s, conf=%.3f, iou=%.3f, max_det=%d, tracker=%s)",
             stream,
@@ -812,6 +818,7 @@ class YOLOEEngine:
             input_hint=input_hint,
             original_image=original_image,
             path=path,
+            allow_unbounded_live=stream,
         )
         if stream:
             return results

--- a/yoloe_tensorrt/gstreamer.py
+++ b/yoloe_tensorrt/gstreamer.py
@@ -13,6 +13,17 @@ LOGGER = get_logger(__name__)
 _GST = None
 _GST_APP = None
 _GST_VIDEO = None
+_RTSP_SCHEMES = (
+    "rtsp://",
+    "rtsps://",
+    "rtspu://",
+    "rtspt://",
+    "rtsph://",
+    "rtsp-sdp://",
+    "rtspsu://",
+    "rtspst://",
+    "rtspsh://",
+)
 
 
 def _require_gst():
@@ -38,6 +49,16 @@ def _require_gst():
     _GST_APP = GstApp
     _GST_VIDEO = GstVideo
     return Gst, GstApp, GstVideo
+
+
+def is_rtsp_uri(source_value: str | Path) -> bool:
+    source_text = str(source_value).strip().lower()
+    return source_text.startswith(_RTSP_SCHEMES)
+
+
+def _gst_quote(value: str) -> str:
+    escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{escaped}"'
 
 
 def build_usb_camera_pipeline(
@@ -69,6 +90,36 @@ def build_usb_camera_pipeline(
     return pipeline
 
 
+def build_rtsp_pipeline(
+    uri: str,
+    width: int | None = None,
+    height: int | None = None,
+    fps: int | None = None,
+    appsink_name: str = "sink",
+) -> str:
+    pipeline = (
+        f"uridecodebin uri={_gst_quote(str(uri).strip())} use-buffering=false ! "
+        "queue max-size-buffers=1 max-size-bytes=0 max-size-time=0 leaky=downstream ! "
+        "autovideoconvert ! video/x-raw ! "
+    )
+
+    caps_parts = ["format=BGR"]
+    if width is not None or height is not None or fps is not None:
+        pipeline += "videoscale ! videorate ! "
+        if width is not None:
+            caps_parts.append(f"width={int(width)}")
+        if height is not None:
+            caps_parts.append(f"height={int(height)}")
+        if fps is not None:
+            caps_parts.append(f"framerate={int(fps)}/1")
+
+    caps = "video/x-raw," + ",".join(caps_parts)
+    pipeline += (
+        f"videoconvert ! {caps} ! appsink name={appsink_name} emit-signals=false max-buffers=1 drop=true sync=false"
+    )
+    return pipeline
+
+
 def build_dummy_video_pipeline(
     width: int = 640,
     height: int = 480,
@@ -88,15 +139,28 @@ def build_dummy_video_pipeline(
 def camera_source_from_spec(
     source_value: str | Path,
     *,
-    width: int = 640,
-    height: int = 480,
-    fps: int = 30,
+    width: int | None = None,
+    height: int | None = None,
+    fps: int | None = None,
     timeout_s: float = 5.0,
     prefix: str = "camera",
     max_frames: int | None = None,
 ) -> GStreamerSource:
     source_text = str(source_value).strip()
     lowered = source_text.lower()
+    resolved_width = 640 if width is None else int(width)
+    resolved_height = 480 if height is None else int(height)
+    resolved_fps = 30 if fps is None else int(fps)
+    if is_rtsp_uri(source_text):
+        return GStreamerSource.rtsp(
+            source_text,
+            width=width,
+            height=height,
+            fps=fps,
+            max_frames=max_frames,
+            timeout_s=timeout_s,
+            prefix=prefix,
+        )
     if "!" in source_text:
         return GStreamerSource(
             pipeline=source_text,
@@ -109,9 +173,9 @@ def camera_source_from_spec(
         pattern = pattern or "ball"
         return GStreamerSource(
             pipeline=build_dummy_video_pipeline(
-                width=width,
-                height=height,
-                fps=fps,
+                width=resolved_width,
+                height=resolved_height,
+                fps=resolved_fps,
                 pattern=pattern,
             ),
             prefix=prefix,
@@ -124,9 +188,9 @@ def camera_source_from_spec(
         raise FileNotFoundError(f"Camera source device is missing: {device_path}")
     return GStreamerSource.usb_camera(
         device=device_path,
-        width=width,
-        height=height,
-        fps=fps,
+        width=resolved_width,
+        height=resolved_height,
+        fps=resolved_fps,
         max_frames=max_frames,
         timeout_s=timeout_s,
         prefix=prefix,
@@ -141,6 +205,29 @@ class GStreamerSource(SourceStream):
     timeout_s: float = 5.0
     appsink_name: str = "sink"
     is_live_source: bool = True
+
+    @classmethod
+    def rtsp(
+        cls,
+        uri: str,
+        width: int | None = None,
+        height: int | None = None,
+        fps: int | None = None,
+        max_frames: int | None = None,
+        timeout_s: float = 5.0,
+        prefix: str | None = None,
+    ) -> GStreamerSource:
+        return cls(
+            pipeline=build_rtsp_pipeline(
+                uri,
+                width=width,
+                height=height,
+                fps=fps,
+            ),
+            prefix=prefix or "rtsp",
+            max_frames=max_frames,
+            timeout_s=timeout_s,
+        )
 
     @classmethod
     def usb_camera(

--- a/yoloe_tensorrt/gui.py
+++ b/yoloe_tensorrt/gui.py
@@ -618,7 +618,12 @@ def run_camera_gui(
 
 def _build_arg_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Launch the YOLOE TensorRT live camera GUI.")
-    parser.add_argument("--source", default=DEFAULT_GUI_SOURCE, help="Initial camera source. Defaults to /dev/video0.")
+    parser.add_argument(
+        "--source",
+        default=DEFAULT_GUI_SOURCE,
+        help="Initial camera source. Accepts /dev/video*, rtsp://..., videotest://..., or a raw GStreamer pipeline. "
+        "Defaults to /dev/video0.",
+    )
     parser.add_argument(
         "--label",
         action="append",

--- a/yoloe_tensorrt/inputs.py
+++ b/yoloe_tensorrt/inputs.py
@@ -9,8 +9,18 @@ import numpy as np
 import torch
 from PIL import Image
 
+from .gstreamer import camera_source_from_spec, is_rtsp_uri
 from .logging_utils import get_logger
-from .source import SourceItem, SourceStream, _is_iterable_source, _load_path, _normalize_array, _pil_to_bgr
+from .source import (
+    SourceItem,
+    SourceStream,
+    _is_iterable_source,
+    _load_path,
+    _normalize_array,
+    _pil_to_bgr,
+    is_finite_live_source,
+    is_live_source,
+)
 
 LOGGER = get_logger(__name__)
 
@@ -64,6 +74,7 @@ def normalize_inference_source(
             default_prefix=default_prefix,
             input_hint=input_hint,
             cuda=cuda,
+            allow_unbounded_live=False,
             original_image=original_image,
             path=path,
         )
@@ -80,11 +91,14 @@ def iter_inference_sources(
     default_prefix: str = "image",
     input_hint: str | None = None,
     cuda: bool | None = None,
+    allow_unbounded_live: bool = True,
     original_image: SourceItem | object | None = None,
     path: str | None = None,
 ) -> Iterator[InferenceSourceItem]:
     hint = normalize_input_hint(input_hint)
     if isinstance(source, SourceStream):
+        if not allow_unbounded_live and is_live_source(source) and not is_finite_live_source(source):
+            raise ValueError("Live sources require stream=True or an explicit max_frames limit")
         yield from source
         return
     if isinstance(source, (SourceItem, PreparedTensorInput)):
@@ -101,6 +115,17 @@ def iter_inference_sources(
         )
         return
     if isinstance(source, (str, Path)):
+        if is_rtsp_uri(source):
+            if not allow_unbounded_live:
+                raise ValueError("Live sources require stream=True or an explicit max_frames limit")
+            yield from camera_source_from_spec(
+                source,
+                width=None,
+                height=None,
+                fps=None,
+                prefix=path or "rtsp",
+            )
+            return
         yield _load_path(source)
         return
     if isinstance(source, Image.Image):
@@ -117,6 +142,7 @@ def iter_inference_sources(
                 default_prefix=f"{default_prefix}{index}",
                 input_hint=hint,
                 cuda=cuda,
+                allow_unbounded_live=allow_unbounded_live,
                 original_image=None,
                 path=item_path,
             )


### PR DESCRIPTION
- Added first-class RTSP input support so plain `rtsp://...` and `rtsps://...` sources can be used without writing a custom GStreamer pipeline.