### PR TITLE
feat: add Jetson zero-copy camera ingest path and RTSP live-source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Fixed unit-range float preprocessing so non-square padded inputs keep the correct scale instead of being divided by `255` a second time.
 - Expanded runtime and unit coverage for unified routing, benchmark CLI help, tracker-session input handling, and prepared-tensor regressions.
 - Added first-class RTSP input support so plain `rtsp://...` and `rtsps://...` sources can be used without writing a custom GStreamer pipeline.
+- Added an optional Jetson zero-copy camera ingest path that maps NVMM frames through EGL/CUDA, emits prepared tensors for inference, and falls back to the CPU appsink path when zero-copy is unavailable.
 
 ## 0.1.3
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 option(YOLOE_TRT_BUILD_NATIVE "Build the native TensorRT extension" ON)
+option(YOLOE_TRT_BUILD_JETSON_CAMERA "Build the Jetson zero-copy camera backend when dependencies are available" ON)
 
 if(NOT YOLOE_TRT_BUILD_NATIVE)
   message(STATUS "YOLOE_TRT_BUILD_NATIVE=OFF, skipping native extension build")
@@ -15,6 +16,7 @@ if(NOT YOLOE_TRT_BUILD_NATIVE)
 endif()
 
 find_package(Python REQUIRED COMPONENTS Interpreter Development.Module)
+include(CheckLanguage)
 find_package(pybind11 CONFIG QUIET)
 if(NOT pybind11_FOUND)
   execute_process(
@@ -91,7 +93,65 @@ find_path(
 message(STATUS "Found TensorRT include dir: ${TENSORRT_INCLUDE_DIR}")
 message(STATUS "Found TensorRT library: ${TENSORRT_LIBRARY}")
 
-pybind11_add_module(_native MODULE src/native/main.cpp)
+set(NATIVE_SOURCES src/native/main.cpp)
+set(NATIVE_EXTRA_LIBS "")
+set(NATIVE_EXTRA_INCLUDE_DIRS "")
+set(NATIVE_EXTRA_COMPILE_DEFINITIONS "")
+
+if(YOLOE_TRT_BUILD_JETSON_CAMERA)
+  check_language(CUDA)
+  if(CMAKE_CUDA_COMPILER)
+    enable_language(CUDA)
+
+    pkg_check_modules(GSTREAMER QUIET IMPORTED_TARGET gstreamer-1.0)
+    pkg_check_modules(GSTREAMER_APP QUIET IMPORTED_TARGET gstreamer-app-1.0)
+    pkg_check_modules(GSTREAMER_ALLOCATORS QUIET IMPORTED_TARGET gstreamer-allocators-1.0)
+    pkg_check_modules(GSTREAMER_VIDEO QUIET IMPORTED_TARGET gstreamer-video-1.0)
+    pkg_check_modules(EGL QUIET IMPORTED_TARGET egl)
+
+    find_path(
+      NVBUFSURFACE_INCLUDE_DIR
+      NvBufSurface.h
+      HINTS
+        /usr/src/jetson_multimedia_api/include
+        /usr/include
+        /usr/local/include
+    )
+    find_library(
+      NVBUFSURFACE_LIBRARY
+      nvbufsurface
+      HINTS
+        /usr/lib/${CMAKE_LIBRARY_ARCHITECTURE}/nvidia
+        /usr/lib/${CMAKE_LIBRARY_ARCHITECTURE}
+        /lib/${CMAKE_LIBRARY_ARCHITECTURE}
+        /usr/lib
+        /lib
+    )
+
+    if(GSTREAMER_FOUND AND GSTREAMER_APP_FOUND AND GSTREAMER_ALLOCATORS_FOUND AND GSTREAMER_VIDEO_FOUND AND EGL_FOUND AND NVBUFSURFACE_INCLUDE_DIR AND NVBUFSURFACE_LIBRARY)
+      list(APPEND NATIVE_SOURCES src/native/jetson_camera_kernels.cu)
+      list(APPEND NATIVE_EXTRA_LIBS
+        PkgConfig::GSTREAMER
+        PkgConfig::GSTREAMER_APP
+        PkgConfig::GSTREAMER_ALLOCATORS
+        PkgConfig::GSTREAMER_VIDEO
+        PkgConfig::EGL
+        ${NVBUFSURFACE_LIBRARY}
+        CUDA::cuda_driver
+      )
+      list(APPEND NATIVE_EXTRA_INCLUDE_DIRS ${NVBUFSURFACE_INCLUDE_DIR})
+      list(APPEND NATIVE_EXTRA_COMPILE_DEFINITIONS YOLOE_TRT_ENABLE_JETSON_CAMERA=1)
+      set_source_files_properties(src/native/jetson_camera_kernels.cu PROPERTIES LANGUAGE CUDA)
+      message(STATUS "Enabling Jetson zero-copy camera backend")
+    else()
+      message(WARNING "Jetson zero-copy camera backend dependencies not found; building without camera backend")
+    endif()
+  else()
+    message(WARNING "CUDA compiler not available; building without Jetson zero-copy camera backend")
+  endif()
+endif()
+
+pybind11_add_module(_native MODULE ${NATIVE_SOURCES})
 
 target_include_directories(
   _native
@@ -99,6 +159,7 @@ target_include_directories(
     ${TENSORRT_INCLUDE_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}/src/native
     ${OpenCV_INCLUDE_DIRS}
+    ${NATIVE_EXTRA_INCLUDE_DIRS}
 )
 
 target_link_libraries(
@@ -107,8 +168,14 @@ target_link_libraries(
     ${TENSORRT_LIBRARY}
     CUDA::cudart
     ${OpenCV_LIBS}
+    ${NATIVE_EXTRA_LIBS}
 )
 
 target_compile_definitions(_native PRIVATE PY_SSIZE_T_CLEAN=1)
+target_compile_definitions(_native PRIVATE ${NATIVE_EXTRA_COMPILE_DEFINITIONS})
+
+if(TARGET _native AND CMAKE_CUDA_COMPILER)
+  set_target_properties(_native PROPERTIES CUDA_STANDARD 17 CUDA_STANDARD_REQUIRED YES)
+endif()
 
 install(TARGETS _native DESTINATION yoloe_tensorrt)

--- a/README.md
+++ b/README.md
@@ -208,7 +208,8 @@ GitHub Actions is the supported automation path for this repository.
 - The prepared-tensor fast path is reached by passing the object returned from `prepare_cuda_input(...)` or by using `input_hint="prepared"`.
 - Plain file paths, PIL images, NumPy arrays, CPU tensors, and CUDA tensors are still accepted without requiring manual preprocessing.
 - For production deployments, prefer `YOLOEEngine.from_engine(...)` and prebuilt bundles over `from_pt(...)`.
-- Live USB camera input is available through a GStreamer appsink pipeline. Jetson zero-copy camera ingest is still on the roadmap.
+- Live camera sources can use a Jetson zero-copy NVMM/EGL/CUDA ingest path when the native camera backend is built and the source negotiates an NVMM pipeline.
+- `camera_source_from_spec(..., target_imgsz=..., zero_copy=None|True|False)` controls that camera ingest policy. `None` auto-selects zero-copy when available, `True` requires it, and `False` forces the fallback CPU appsink path.
 - Direct RTSP URLs such as `rtsp://camera.local/stream` are supported and resolved to a GStreamer RTSP pipeline automatically.
 - If you do not have a camera attached, use `videotest://<pattern>` such as `videotest://ball` or `videotest://smpte`.
 
@@ -234,7 +235,6 @@ GitHub Actions is the supported automation path for this repository.
 
 The project is usable today for Jetson-focused deployments, but it is still early-stage. The remaining performance roadmap is centered on:
 
-- Jetson zero-copy NVMM/EGL/CUDA camera ingest
 - CUDA preprocess instead of CPU/OpenCV preprocess
 - Native decode/NMS/mask reconstruction
 - Native visual-prompt execution

--- a/docs/camera-gui.md
+++ b/docs/camera-gui.md
@@ -35,6 +35,6 @@ track IDs when detections are matched across frames.
 - raw GStreamer pipeline strings are also accepted
 - `videotest://<pattern>` creates a synthetic GStreamer source, for example `videotest://ball` or `videotest://smpte`
 
-## Current limitation
+## Jetson zero-copy path
 
-The camera path still uses an appsink/CPU-memory ingest path. Jetson zero-copy NVMM/EGL/CUDA ingest is still roadmap work.
+On Jetson builds that include the native camera backend, the GUI requests the zero-copy NVMM/EGL/CUDA ingest path automatically and only materializes a CPU preview frame for rendering the window. If zero-copy is unavailable or the source cannot negotiate the required NVMM pipeline, the GUI falls back to the existing CPU appsink path.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -74,6 +74,8 @@ Direct RTSP input is also supported:
 yoloe-camera-gui --source rtsp://user:pass@camera.local:554/stream
 ```
 
+On Jetson builds with the native camera backend available, the GUI will use the zero-copy NVMM/EGL/CUDA ingest path automatically and fall back to the CPU appsink path only when the source cannot satisfy that contract.
+
 The GUI lets you change:
 
 - the video source

--- a/src/native/jetson_camera_kernels.cu
+++ b/src/native/jetson_camera_kernels.cu
@@ -1,0 +1,162 @@
+#include "jetson_camera_kernels.h"
+
+#include <cuda_fp16.h>
+
+#include <cmath>
+#include <cstdint>
+
+namespace {
+
+template <typename T>
+__device__ inline void store_value(T* dst, int offset, float value);
+
+template <>
+__device__ inline void store_value<float>(float* dst, int offset, float value)
+{
+    dst[offset] = value;
+}
+
+template <>
+__device__ inline void store_value<__half>(__half* dst, int offset, float value)
+{
+    dst[offset] = __float2half(value);
+}
+
+template <typename T>
+__global__ void letterbox_bgrx_to_nchw_kernel(
+    unsigned char const* src,
+    int src_width,
+    int src_height,
+    int src_pitch,
+    int dst_width,
+    int dst_height,
+    int resized_width,
+    int resized_height,
+    int pad_left,
+    int pad_top,
+    bool input_is_bgrx,
+    T* dst)
+{
+    int const x = static_cast<int>(blockIdx.x * blockDim.x + threadIdx.x);
+    int const y = static_cast<int>(blockIdx.y * blockDim.y + threadIdx.y);
+    if (x >= dst_width || y >= dst_height) {
+        return;
+    }
+
+    float constexpr kPadValue = 114.0f / 255.0f;
+    int const plane_stride = dst_width * dst_height;
+    int const dst_offset = y * dst_width + x;
+
+    if (x < pad_left || x >= (pad_left + resized_width) || y < pad_top || y >= (pad_top + resized_height)) {
+        store_value(dst, dst_offset, kPadValue);
+        store_value(dst, plane_stride + dst_offset, kPadValue);
+        store_value(dst, (2 * plane_stride) + dst_offset, kPadValue);
+        return;
+    }
+
+    float const src_x = ((static_cast<float>(x - pad_left) + 0.5f) * static_cast<float>(src_width) /
+                            static_cast<float>(resized_width)) -
+        0.5f;
+    float const src_y = ((static_cast<float>(y - pad_top) + 0.5f) * static_cast<float>(src_height) /
+                            static_cast<float>(resized_height)) -
+        0.5f;
+
+    int const x0 = max(0, min(static_cast<int>(floorf(src_x)), src_width - 1));
+    int const y0 = max(0, min(static_cast<int>(floorf(src_y)), src_height - 1));
+    int const x1 = max(0, min(x0 + 1, src_width - 1));
+    int const y1 = max(0, min(y0 + 1, src_height - 1));
+    float const wx = src_x - floorf(src_x);
+    float const wy = src_y - floorf(src_y);
+
+    unsigned char const* row0 = src + static_cast<std::size_t>(y0 * src_pitch);
+    unsigned char const* row1 = src + static_cast<std::size_t>(y1 * src_pitch);
+    unsigned char const* p00 = row0 + static_cast<std::size_t>(x0 * 4);
+    unsigned char const* p01 = row0 + static_cast<std::size_t>(x1 * 4);
+    unsigned char const* p10 = row1 + static_cast<std::size_t>(x0 * 4);
+    unsigned char const* p11 = row1 + static_cast<std::size_t>(x1 * 4);
+
+    auto sample_channel = [&](int index) -> float {
+        float const c00 = static_cast<float>(p00[index]);
+        float const c01 = static_cast<float>(p01[index]);
+        float const c10 = static_cast<float>(p10[index]);
+        float const c11 = static_cast<float>(p11[index]);
+        float const top = c00 + (c01 - c00) * wx;
+        float const bottom = c10 + (c11 - c10) * wx;
+        return (top + (bottom - top) * wy) / 255.0f;
+    };
+
+    float red;
+    float green;
+    float blue;
+    if (input_is_bgrx) {
+        blue = sample_channel(0);
+        green = sample_channel(1);
+        red = sample_channel(2);
+    } else {
+        red = sample_channel(0);
+        green = sample_channel(1);
+        blue = sample_channel(2);
+    }
+
+    store_value(dst, dst_offset, red);
+    store_value(dst, plane_stride + dst_offset, green);
+    store_value(dst, (2 * plane_stride) + dst_offset, blue);
+}
+
+} // namespace
+
+void launch_jetson_zero_copy_preprocess(
+    void const* src_ptr,
+    int src_width,
+    int src_height,
+    int src_pitch,
+    int dst_width,
+    int dst_height,
+    bool input_is_bgrx,
+    bool output_fp16,
+    void* dst_ptr,
+    cudaStream_t stream)
+{
+    float const gain = fminf(
+        static_cast<float>(dst_width) / static_cast<float>(src_width),
+        static_cast<float>(dst_height) / static_cast<float>(src_height));
+    int const resized_width = max(1, static_cast<int>(llroundf(static_cast<float>(src_width) * gain)));
+    int const resized_height = max(1, static_cast<int>(llroundf(static_cast<float>(src_height) * gain)));
+    int const pad_left = (dst_width - resized_width) / 2;
+    int const pad_top = (dst_height - resized_height) / 2;
+
+    dim3 const threads(16, 16);
+    dim3 const blocks(
+        static_cast<unsigned int>((dst_width + threads.x - 1) / threads.x),
+        static_cast<unsigned int>((dst_height + threads.y - 1) / threads.y));
+
+    if (output_fp16) {
+        letterbox_bgrx_to_nchw_kernel<<<blocks, threads, 0, stream>>>(
+            static_cast<unsigned char const*>(src_ptr),
+            src_width,
+            src_height,
+            src_pitch,
+            dst_width,
+            dst_height,
+            resized_width,
+            resized_height,
+            pad_left,
+            pad_top,
+            input_is_bgrx,
+            static_cast<__half*>(dst_ptr));
+    } else {
+        letterbox_bgrx_to_nchw_kernel<<<blocks, threads, 0, stream>>>(
+            static_cast<unsigned char const*>(src_ptr),
+            src_width,
+            src_height,
+            src_pitch,
+            dst_width,
+            dst_height,
+            resized_width,
+            resized_height,
+            pad_left,
+            pad_top,
+            input_is_bgrx,
+            static_cast<float*>(dst_ptr));
+    }
+}

--- a/src/native/jetson_camera_kernels.h
+++ b/src/native/jetson_camera_kernels.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <cuda_runtime_api.h>
+
+void launch_jetson_zero_copy_preprocess(
+    void const* src_ptr,
+    int src_width,
+    int src_height,
+    int src_pitch,
+    int dst_width,
+    int dst_height,
+    bool input_is_bgrx,
+    bool output_fp16,
+    void* dst_ptr,
+    cudaStream_t stream);

--- a/src/native/main.cpp
+++ b/src/native/main.cpp
@@ -5,6 +5,19 @@
 #include <NvInferRuntime.h>
 #include <opencv2/imgproc.hpp>
 
+#ifdef YOLOE_TRT_ENABLE_JETSON_CAMERA
+#include "jetson_camera_kernels.h"
+
+#include <EGL/egl.h>
+#include <cuda.h>
+#include <cudaEGL.h>
+#include <gst/allocators/gstdmabuf.h>
+#include <gst/app/gstappsink.h>
+#include <gst/gst.h>
+#include <gst/video/video.h>
+#include <NvBufSurface.h>
+#endif
+
 #include <pybind11/numpy.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
@@ -15,7 +28,9 @@
 #include <cstdio>
 #include <cstring>
 #include <algorithm>
+#include <deque>
 #include <memory>
+#include <mutex>
 #include <stdexcept>
 #include <string>
 #include <utility>
@@ -193,12 +208,130 @@ struct BindingInfo {
 };
 
 class NativeMainRuntime;
+#ifdef YOLOE_TRT_ENABLE_JETSON_CAMERA
+class NativeJetsonCameraSource;
+#endif
 
 struct ManagedTensorContext {
     std::shared_ptr<NativeMainRuntime> owner;
     std::vector<std::int64_t> shape;
     DLManagedTensor managed{};
 };
+
+#ifdef YOLOE_TRT_ENABLE_JETSON_CAMERA
+struct PendingJetsonFrame {
+    CudaBuffer output_buffer;
+    GstSample* sample = nullptr;
+    NvBufSurface* surface = nullptr;
+    bool mapped_egl = false;
+    CUgraphicsResource resource = nullptr;
+    cudaEvent_t ready_event = nullptr;
+    int device_id = 0;
+
+    PendingJetsonFrame() = default;
+    PendingJetsonFrame(PendingJetsonFrame const&) = delete;
+    PendingJetsonFrame& operator=(PendingJetsonFrame const&) = delete;
+
+    ~PendingJetsonFrame()
+    {
+        release_frame_resources();
+    }
+
+    void record_ready_event(cudaStream_t stream)
+    {
+        throw_if_cuda_failed(cudaSetDevice(device_id), "cudaSetDevice failed for zero-copy frame event");
+        throw_if_cuda_failed(
+            cudaEventCreateWithFlags(&ready_event, cudaEventDisableTiming),
+            "cudaEventCreateWithFlags failed for zero-copy frame event");
+        try {
+            throw_if_cuda_failed(
+                cudaEventRecord(ready_event, stream),
+                "cudaEventRecord failed for zero-copy frame event");
+        } catch (...) {
+            cudaEventDestroy(ready_event);
+            ready_event = nullptr;
+            throw;
+        }
+    }
+
+    void wait_on_consumer_stream(cudaStream_t consumer_stream) const
+    {
+        if (ready_event == nullptr) {
+            return;
+        }
+        throw_if_cuda_failed(cudaSetDevice(device_id), "cudaSetDevice failed for zero-copy DLPack handoff");
+        throw_if_cuda_failed(
+            cudaStreamWaitEvent(consumer_stream, ready_event, 0),
+            "cudaStreamWaitEvent failed for zero-copy DLPack handoff");
+    }
+
+    bool is_ready() const
+    {
+        if (ready_event == nullptr) {
+            return true;
+        }
+        auto const status = cudaEventQuery(ready_event);
+        if (status == cudaSuccess) {
+            return true;
+        }
+        if (status == cudaErrorNotReady) {
+            cudaGetLastError();
+            return false;
+        }
+        throw std::runtime_error(std::string("cudaEventQuery failed for zero-copy frame event: ") + cudaGetErrorString(status));
+    }
+
+    void release_frame_resources() noexcept
+    {
+        if (device_id >= 0) {
+            cudaSetDevice(device_id);
+        }
+        if (resource != nullptr) {
+            cuGraphicsUnregisterResource(resource);
+            resource = nullptr;
+        }
+        if (mapped_egl && surface != nullptr) {
+            NvBufSurfaceUnMapEglImage(surface, 0);
+            mapped_egl = false;
+        }
+        if (ready_event != nullptr) {
+            cudaEventDestroy(ready_event);
+            ready_event = nullptr;
+        }
+        if (sample != nullptr) {
+            gst_sample_unref(sample);
+            sample = nullptr;
+        }
+        surface = nullptr;
+    }
+};
+
+struct ManagedCameraTensorContext {
+    std::shared_ptr<NativeJetsonCameraSource> owner;
+    std::shared_ptr<PendingJetsonFrame> frame;
+    std::vector<std::int64_t> shape;
+    DLManagedTensor managed{};
+};
+
+inline cudaStream_t parse_dlpack_consumer_stream(py::object const& stream)
+{
+    if (stream.is_none()) {
+        return cudaStreamLegacy;
+    }
+
+    auto const value = stream.cast<std::int64_t>();
+    if (value == 1) {
+        return cudaStreamLegacy;
+    }
+    if (value == 2) {
+        return cudaStreamPerThread;
+    }
+    if (value == 0 || value < 0) {
+        throw std::runtime_error("Invalid CUDA DLPack consumer stream value");
+    }
+    return reinterpret_cast<cudaStream_t>(static_cast<std::uintptr_t>(value));
+}
+#endif
 
 class CudaTensorView {
 public:
@@ -257,6 +390,73 @@ private:
     nvinfer1::DataType dtype_ = nvinfer1::DataType::kFLOAT;
     int device_id_ = 0;
 };
+
+#ifdef YOLOE_TRT_ENABLE_JETSON_CAMERA
+class CameraCudaTensorView {
+public:
+    CameraCudaTensorView(
+        std::shared_ptr<NativeJetsonCameraSource> owner,
+        std::shared_ptr<PendingJetsonFrame> frame,
+        void* ptr,
+        std::vector<std::int64_t> shape,
+        nvinfer1::DataType dtype,
+        int device_id)
+        : owner_(std::move(owner))
+        , frame_(std::move(frame))
+        , ptr_(ptr)
+        , shape_(std::move(shape))
+        , dtype_(dtype)
+        , device_id_(device_id)
+    {
+    }
+
+    py::capsule dlpack(py::object stream) const
+    {
+        if (frame_ != nullptr) {
+            frame_->wait_on_consumer_stream(parse_dlpack_consumer_stream(stream));
+        }
+        auto* ctx = new ManagedCameraTensorContext();
+        ctx->owner = owner_;
+        ctx->frame = frame_;
+        ctx->shape = shape_;
+        ctx->managed.manager_ctx = ctx;
+        ctx->managed.deleter = [](DLManagedTensor* self) {
+            auto* managed_ctx = static_cast<ManagedCameraTensorContext*>(self->manager_ctx);
+            delete managed_ctx;
+        };
+        ctx->managed.dl_tensor.data = ptr_;
+        ctx->managed.dl_tensor.device = DLDevice{kDLCUDA, device_id_};
+        ctx->managed.dl_tensor.ndim = static_cast<int>(ctx->shape.size());
+        ctx->managed.dl_tensor.dtype = to_dlpack_dtype(dtype_);
+        ctx->managed.dl_tensor.shape = ctx->shape.data();
+        ctx->managed.dl_tensor.strides = nullptr;
+        ctx->managed.dl_tensor.byte_offset = 0;
+
+        py::capsule capsule(&ctx->managed, "dltensor", [](PyObject* obj) {
+            if (PyCapsule_IsValid(obj, "dltensor")) {
+                auto* managed = static_cast<DLManagedTensor*>(PyCapsule_GetPointer(obj, "dltensor"));
+                if (managed != nullptr && managed->deleter != nullptr) {
+                    managed->deleter(managed);
+                }
+            }
+        });
+        return capsule;
+    }
+
+    py::tuple dlpack_device() const
+    {
+        return py::make_tuple(static_cast<int>(kDLCUDA), device_id_);
+    }
+
+private:
+    std::shared_ptr<NativeJetsonCameraSource> owner_;
+    std::shared_ptr<PendingJetsonFrame> frame_;
+    void* ptr_ = nullptr;
+    std::vector<std::int64_t> shape_;
+    nvinfer1::DataType dtype_ = nvinfer1::DataType::kFLOAT;
+    int device_id_ = 0;
+};
+#endif
 
 class NativeMainRuntime : public std::enable_shared_from_this<NativeMainRuntime> {
 public:
@@ -716,6 +916,398 @@ private:
     std::vector<__half> prompt_half_host_;
 };
 
+#ifdef YOLOE_TRT_ENABLE_JETSON_CAMERA
+void ensure_gstreamer_initialized()
+{
+    static std::once_flag init_flag;
+    std::call_once(init_flag, []() {
+        gst_init(nullptr, nullptr);
+    });
+}
+
+class NativeJetsonCameraSource : public std::enable_shared_from_this<NativeJetsonCameraSource> {
+public:
+    NativeJetsonCameraSource(
+        std::string pipeline,
+        std::string prefix,
+        double timeout_s,
+        int target_h,
+        int target_w,
+        bool fp16,
+        bool preview_cpu,
+        int device_id)
+        : pipeline_spec_(std::move(pipeline))
+        , prefix_(std::move(prefix))
+        , timeout_ns_(static_cast<GstClockTime>(timeout_s * 1'000'000'000.0))
+        , target_h_(target_h)
+        , target_w_(target_w)
+        , fp16_(fp16)
+        , preview_cpu_(preview_cpu)
+        , device_id_(device_id)
+        , output_dtype_(fp16 ? nvinfer1::DataType::kHALF : nvinfer1::DataType::kFLOAT)
+    {
+        throw_if_cuda_failed(cudaSetDevice(device_id_), "cudaSetDevice failed");
+        throw_if_cuda_failed(cudaStreamCreate(&stream_), "cudaStreamCreate failed");
+    }
+
+    ~NativeJetsonCameraSource()
+    {
+        close();
+        if (stream_ != nullptr) {
+            cudaStreamDestroy(stream_);
+            stream_ = nullptr;
+        }
+    }
+
+    py::object read_frame()
+    {
+        open_if_needed();
+        cleanup_completed_frames();
+
+        GstSample* sample = gst_app_sink_try_pull_sample(appsink_, timeout_ns_);
+        if (sample == nullptr) {
+            if (gst_app_sink_is_eos(appsink_)) {
+                return py::none();
+            }
+            if (auto* message = gst_bus_timed_pop_filtered(bus_, 0, static_cast<GstMessageType>(GST_MESSAGE_ERROR | GST_MESSAGE_EOS | GST_MESSAGE_WARNING))) {
+                if (GST_MESSAGE_TYPE(message) == GST_MESSAGE_ERROR) {
+                    GError* error = nullptr;
+                    gchar* debug = nullptr;
+                    gst_message_parse_error(message, &error, &debug);
+                    std::string message_text = error != nullptr ? error->message : "unknown";
+                    std::string debug_text = debug != nullptr ? debug : "";
+                    if (error != nullptr) {
+                        g_error_free(error);
+                    }
+                    if (debug != nullptr) {
+                        g_free(debug);
+                    }
+                    gst_message_unref(message);
+                    throw std::runtime_error("GStreamer source error: " + message_text + "; debug=" + debug_text);
+                }
+                if (GST_MESSAGE_TYPE(message) == GST_MESSAGE_EOS) {
+                    gst_message_unref(message);
+                    return py::none();
+                }
+                gst_message_unref(message);
+            }
+            throw std::runtime_error("Timed out waiting for a frame from zero-copy GStreamer source");
+        }
+
+        return frame_from_sample(sample);
+    }
+
+    void close()
+    {
+        if (stream_ != nullptr) {
+            cudaSetDevice(device_id_);
+            cudaStreamSynchronize(stream_);
+        }
+        while (!pending_frames_.empty()) {
+            pending_frames_.front()->release_frame_resources();
+            pending_frames_.pop_front();
+        }
+        reusable_frames_.clear();
+        if (pipeline_ != nullptr) {
+            gst_element_set_state(pipeline_, GST_STATE_NULL);
+            gst_element_get_state(pipeline_, nullptr, nullptr, timeout_ns_);
+        }
+        if (appsink_ != nullptr) {
+            gst_object_unref(appsink_);
+            appsink_ = nullptr;
+        }
+        if (bus_ != nullptr) {
+            gst_object_unref(bus_);
+            bus_ = nullptr;
+        }
+        if (pipeline_ != nullptr) {
+            gst_object_unref(pipeline_);
+            pipeline_ = nullptr;
+        }
+        frame_index_ = 0;
+        started_ = false;
+    }
+
+private:
+    std::shared_ptr<PendingJetsonFrame> acquire_frame_slot(std::size_t bytes)
+    {
+        throw_if_cuda_failed(cudaSetDevice(device_id_), "cudaSetDevice failed during zero-copy frame allocation");
+        while (!reusable_frames_.empty()) {
+            auto frame = reusable_frames_.front();
+            reusable_frames_.pop_front();
+            if (frame.use_count() != 1) {
+                continue;
+            }
+            frame->output_buffer.ensure(bytes);
+            return frame;
+        }
+
+        auto frame = std::make_shared<PendingJetsonFrame>();
+        frame->device_id = device_id_;
+        frame->output_buffer.ensure(bytes);
+        return frame;
+    }
+
+    void cleanup_completed_frames()
+    {
+        throw_if_cuda_failed(cudaSetDevice(device_id_), "cudaSetDevice failed during zero-copy frame cleanup");
+        while (!pending_frames_.empty()) {
+            auto frame = pending_frames_.front();
+            if (!frame->is_ready()) {
+                break;
+            }
+            frame->release_frame_resources();
+            pending_frames_.pop_front();
+            if (frame.use_count() == 1) {
+                reusable_frames_.push_back(std::move(frame));
+            }
+        }
+    }
+
+    void open_if_needed()
+    {
+        if (started_) {
+            return;
+        }
+
+        ensure_gstreamer_initialized();
+
+        GError* error = nullptr;
+        pipeline_ = gst_parse_launch(pipeline_spec_.c_str(), &error);
+        if (pipeline_ == nullptr) {
+            std::string message = error != nullptr ? error->message : "unknown";
+            if (error != nullptr) {
+                g_error_free(error);
+            }
+            throw std::runtime_error("Unable to parse GStreamer pipeline: " + message);
+        }
+
+        auto* appsink_element = gst_bin_get_by_name(GST_BIN(pipeline_), "sink");
+        if (appsink_element == nullptr) {
+            close();
+            throw std::runtime_error("GStreamer pipeline did not expose appsink 'sink': " + pipeline_spec_);
+        }
+        if (!GST_IS_APP_SINK(appsink_element)) {
+            gst_object_unref(appsink_element);
+            close();
+            throw std::runtime_error("Pipeline element 'sink' is not a GstAppSink");
+        }
+        appsink_ = GST_APP_SINK(appsink_element);
+        bus_ = gst_element_get_bus(pipeline_);
+
+        if (gst_element_set_state(pipeline_, GST_STATE_PLAYING) == GST_STATE_CHANGE_FAILURE) {
+            close();
+            throw std::runtime_error("Unable to start GStreamer pipeline: " + pipeline_spec_);
+        }
+        gst_element_get_state(pipeline_, nullptr, nullptr, timeout_ns_);
+        started_ = true;
+    }
+
+    py::array preview_from_surface(NvBufSurface* surface, int width, int height, bool input_is_bgrx)
+    {
+        if (!preview_cpu_) {
+            return py::array();
+        }
+        if (NvBufSurfaceMap(surface, 0, 0, NVBUF_MAP_READ) != 0) {
+            throw std::runtime_error("NvBufSurfaceMap failed for preview frame");
+        }
+        if (NvBufSurfaceSyncForCpu(surface, 0, 0) != 0) {
+            NvBufSurfaceUnMap(surface, 0, 0);
+            throw std::runtime_error("NvBufSurfaceSyncForCpu failed for preview frame");
+        }
+
+        try {
+            auto* mapped = static_cast<unsigned char*>(surface->surfaceList[0].mappedAddr.addr[0]);
+            int const pitch = static_cast<int>(surface->surfaceList[0].pitch);
+            if (mapped == nullptr || pitch <= 0) {
+                throw std::runtime_error("Preview frame did not expose CPU-mappable image data");
+            }
+            cv::Mat const src(height, width, CV_8UC4, mapped, static_cast<std::size_t>(pitch));
+            cv::Mat bgr;
+            cv::cvtColor(src, bgr, input_is_bgrx ? cv::COLOR_BGRA2BGR : cv::COLOR_RGBA2BGR);
+            py::array_t<std::uint8_t> array({ bgr.rows, bgr.cols, bgr.channels() });
+            auto const info = array.request();
+            std::memcpy(info.ptr, bgr.data, static_cast<std::size_t>(bgr.rows * bgr.cols * bgr.channels()));
+            NvBufSurfaceUnMap(surface, 0, 0);
+            return array;
+        } catch (...) {
+            NvBufSurfaceUnMap(surface, 0, 0);
+            throw;
+        }
+    }
+
+    py::dict frame_from_sample(GstSample* sample)
+    {
+        auto* caps = gst_sample_get_caps(sample);
+        if (caps == nullptr) {
+            gst_sample_unref(sample);
+            throw std::runtime_error("GStreamer sample did not include caps");
+        }
+        auto* structure = gst_caps_get_structure(caps, 0);
+        int width = 0;
+        int height = 0;
+        if (!gst_structure_get_int(structure, "width", &width) || !gst_structure_get_int(structure, "height", &height)) {
+            gst_sample_unref(sample);
+            throw std::runtime_error("Unable to read GStreamer frame dimensions");
+        }
+        char const* format_name = gst_structure_get_string(structure, "format");
+        if (format_name == nullptr) {
+            gst_sample_unref(sample);
+            throw std::runtime_error("Unable to read GStreamer frame format");
+        }
+        bool const input_is_bgrx = std::string(format_name) == "BGRx";
+        if (!input_is_bgrx && std::string(format_name) != "RGBA") {
+            gst_sample_unref(sample);
+            throw std::runtime_error("Zero-copy source expects BGRx or RGBA NVMM frames, got: " + std::string(format_name));
+        }
+
+        auto* buffer = gst_sample_get_buffer(sample);
+        if (buffer == nullptr || gst_buffer_n_memory(buffer) <= 0) {
+            gst_sample_unref(sample);
+            throw std::runtime_error("GStreamer sample did not include a buffer");
+        }
+        auto* memory = gst_buffer_peek_memory(buffer, 0);
+        if (memory == nullptr || !gst_is_dmabuf_memory(memory)) {
+            gst_sample_unref(sample);
+            throw std::runtime_error("Zero-copy camera source requires DMABUF-backed NVMM frames");
+        }
+        int const dmabuf_fd = gst_dmabuf_memory_get_fd(memory);
+        if (dmabuf_fd < 0) {
+            gst_sample_unref(sample);
+            throw std::runtime_error("Unable to extract DMABUF fd from GStreamer sample");
+        }
+
+        NvBufSurface* surface = nullptr;
+        if (NvBufSurfaceFromFd(dmabuf_fd, reinterpret_cast<void**>(&surface)) != 0 || surface == nullptr) {
+            gst_sample_unref(sample);
+            throw std::runtime_error("NvBufSurfaceFromFd failed for zero-copy frame");
+        }
+
+        py::object preview = py::none();
+        if (preview_cpu_) {
+            try {
+                preview = preview_from_surface(surface, width, height, input_is_bgrx);
+            } catch (...) {
+                gst_sample_unref(sample);
+                throw;
+            }
+        }
+
+        bool mapped_egl = false;
+        if (surface->surfaceList[0].mappedAddr.eglImage == nullptr) {
+            if (NvBufSurfaceMapEglImage(surface, 0) != 0) {
+                gst_sample_unref(sample);
+                throw std::runtime_error("NvBufSurfaceMapEglImage failed for zero-copy frame");
+            }
+            mapped_egl = true;
+        }
+
+        auto egl_image = surface->surfaceList[0].mappedAddr.eglImage;
+        if (egl_image == nullptr) {
+            if (mapped_egl) {
+                NvBufSurfaceUnMapEglImage(surface, 0);
+            }
+            gst_sample_unref(sample);
+            throw std::runtime_error("EGL image was unavailable for zero-copy frame");
+        }
+
+        CUgraphicsResource resource = nullptr;
+        CUeglFrame egl_frame{};
+        cudaFree(0);
+        if (cuGraphicsEGLRegisterImage(&resource, egl_image, CU_GRAPHICS_MAP_RESOURCE_FLAGS_NONE) != CUDA_SUCCESS) {
+            if (mapped_egl) {
+                NvBufSurfaceUnMapEglImage(surface, 0);
+            }
+            gst_sample_unref(sample);
+            throw std::runtime_error("cuGraphicsEGLRegisterImage failed for zero-copy frame");
+        }
+
+        try {
+            if (cuGraphicsResourceGetMappedEglFrame(&egl_frame, resource, 0, 0) != CUDA_SUCCESS) {
+                throw std::runtime_error("cuGraphicsResourceGetMappedEglFrame failed for zero-copy frame");
+            }
+            if (egl_frame.frameType != CU_EGL_FRAME_TYPE_PITCH) {
+                throw std::runtime_error("Zero-copy source only supports pitch-linear EGL frames");
+            }
+
+            auto const plane_elements = static_cast<std::size_t>(target_h_) * static_cast<std::size_t>(target_w_) * 3U;
+            auto pending_frame = acquire_frame_slot(plane_elements * dtype_size(output_dtype_));
+            launch_jetson_zero_copy_preprocess(
+                egl_frame.frame.pPitch[0],
+                width,
+                height,
+                static_cast<int>(egl_frame.pitch),
+                target_w_,
+                target_h_,
+                input_is_bgrx,
+                fp16_,
+                pending_frame->output_buffer.data(),
+                stream_);
+            throw_if_cuda_failed(cudaGetLastError(), "Jetson zero-copy preprocess kernel launch failed");
+
+            pending_frame->record_ready_event(stream_);
+            pending_frame->sample = sample;
+            pending_frame->surface = surface;
+            pending_frame->mapped_egl = mapped_egl;
+            pending_frame->resource = resource;
+            pending_frames_.push_back(pending_frame);
+            sample = nullptr;
+            surface = nullptr;
+            mapped_egl = false;
+            resource = nullptr;
+
+            py::dict result;
+            result["tensor"] = CameraCudaTensorView(
+                shared_from_this(),
+                pending_frame,
+                pending_frame->output_buffer.data(),
+                { 1, 3, target_h_, target_w_ },
+                output_dtype_,
+                device_id_);
+            result["path"] = prefix_ + "_frame" + [&]() {
+                char buffer[32];
+                std::snprintf(buffer, sizeof(buffer), "%06zu", frame_index_);
+                return std::string(buffer);
+            }();
+            result["original_shape"] = py::make_tuple(height, width);
+            result["producer_stream"] = reinterpret_cast<std::uintptr_t>(stream_);
+            result["preview"] = preview;
+            ++frame_index_;
+            return result;
+        } catch (...) {
+            if (resource != nullptr) {
+                cuGraphicsUnregisterResource(resource);
+            }
+            if (mapped_egl && surface != nullptr) {
+                NvBufSurfaceUnMapEglImage(surface, 0);
+            }
+            if (sample != nullptr) {
+                gst_sample_unref(sample);
+            }
+            throw;
+        }
+    }
+
+    std::string pipeline_spec_;
+    std::string prefix_;
+    GstClockTime timeout_ns_ = 0;
+    int target_h_ = 0;
+    int target_w_ = 0;
+    bool fp16_ = false;
+    bool preview_cpu_ = false;
+    int device_id_ = 0;
+    nvinfer1::DataType output_dtype_ = nvinfer1::DataType::kFLOAT;
+    cudaStream_t stream_ = nullptr;
+    GstElement* pipeline_ = nullptr;
+    GstAppSink* appsink_ = nullptr;
+    GstBus* bus_ = nullptr;
+    bool started_ = false;
+    std::size_t frame_index_ = 0;
+    std::deque<std::shared_ptr<PendingJetsonFrame>> pending_frames_;
+    std::deque<std::shared_ptr<PendingJetsonFrame>> reusable_frames_;
+};
+#endif
+
 } // namespace
 
 PYBIND11_MODULE(_native, m)
@@ -725,6 +1317,12 @@ PYBIND11_MODULE(_native, m)
     py::class_<CudaTensorView>(m, "CudaTensorView")
         .def("__dlpack__", [](CudaTensorView const& self, py::object) { return self.dlpack(); }, py::arg("stream") = py::none())
         .def("__dlpack_device__", &CudaTensorView::dlpack_device);
+
+#ifdef YOLOE_TRT_ENABLE_JETSON_CAMERA
+    py::class_<CameraCudaTensorView>(m, "CameraCudaTensorView")
+        .def("__dlpack__", [](CameraCudaTensorView const& self, py::object stream) { return self.dlpack(std::move(stream)); }, py::arg("stream") = py::none())
+        .def("__dlpack_device__", &CameraCudaTensorView::dlpack_device);
+#endif
 
     py::class_<NativeMainRuntime, std::shared_ptr<NativeMainRuntime>>(m, "NativeMainRuntime")
         .def(py::init<std::string, std::string, std::string, int>(), py::arg("engine_path"), py::arg("image_input_name"), py::arg("prompt_input_name"), py::arg("device_id") = 0)
@@ -741,4 +1339,20 @@ PYBIND11_MODULE(_native, m)
             py::arg("target_w"),
             py::arg("producer_stream") = 0)
         .def("warmup", &NativeMainRuntime::warmup, py::arg("target_h"), py::arg("target_w"), py::arg("prompt_count"), py::arg("runs") = 2);
+
+#ifdef YOLOE_TRT_ENABLE_JETSON_CAMERA
+    py::class_<NativeJetsonCameraSource, std::shared_ptr<NativeJetsonCameraSource>>(m, "NativeJetsonCameraSource")
+        .def(
+            py::init<std::string, std::string, double, int, int, bool, bool, int>(),
+            py::arg("pipeline"),
+            py::arg("prefix"),
+            py::arg("timeout_s"),
+            py::arg("target_h"),
+            py::arg("target_w"),
+            py::arg("fp16"),
+            py::arg("preview_cpu") = false,
+            py::arg("device_id") = 0)
+        .def("read_frame", &NativeJetsonCameraSource::read_frame)
+        .def("close", &NativeJetsonCameraSource::close);
+#endif
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,6 @@ from pathlib import Path
 import pytest
 import torch
 from yoloe_tensorrt import (
-    GStreamerSource,
     YOLOEEngine,
     camera_source_from_spec,
     configure_logging,
@@ -129,13 +128,15 @@ def camera_max_frames(pytestconfig: pytest.Config) -> int | None:
 
 
 @pytest.fixture(scope="session")
-def make_camera_source():
+def make_camera_source(integration_imgsz: int):
     width = int(os.environ.get("YOLOE_TRT_TEST_CAMERA_WIDTH", "640"))
     height = int(os.environ.get("YOLOE_TRT_TEST_CAMERA_HEIGHT", "480"))
     fps = int(os.environ.get("YOLOE_TRT_TEST_CAMERA_FPS", "30"))
     timeout_s = float(os.environ.get("YOLOE_TRT_TEST_CAMERA_TIMEOUT", "5.0"))
+    zero_copy = os.environ.get("YOLOE_TRT_TEST_CAMERA_ZERO_COPY", "").lower()
+    zero_copy_value = None if zero_copy == "" else zero_copy not in {"0", "false", "no"}
 
-    def _make(source_value: str, *, prefix: str, max_frames: int | None) -> GStreamerSource:
+    def _make(source_value: str, *, prefix: str, max_frames: int | None):
         try:
             return camera_source_from_spec(
                 source_value,
@@ -145,6 +146,9 @@ def make_camera_source():
                 max_frames=max_frames,
                 timeout_s=timeout_s,
                 prefix=prefix,
+                zero_copy=zero_copy_value,
+                target_imgsz=integration_imgsz,
+                fp16=True,
             )
         except FileNotFoundError as exc:
             pytest.skip(str(exc))
@@ -153,7 +157,7 @@ def make_camera_source():
 
 
 @pytest.fixture(scope="session")
-def usb_camera_source(pytestconfig: pytest.Config, make_camera_source) -> GStreamerSource:
+def usb_camera_source(pytestconfig: pytest.Config, make_camera_source):
     try:
         return make_camera_source(
             str(pytestconfig.getoption("--camera-source")),

--- a/tests/test_engine_fast_path.py
+++ b/tests/test_engine_fast_path.py
@@ -7,7 +7,28 @@ import torch
 from ultralytics.engine.results import Results
 from yoloe_tensorrt.engine import YOLOEEngine
 from yoloe_tensorrt.inputs import PreparedTensorInput
-from yoloe_tensorrt.source import SourceItem
+from yoloe_tensorrt.source import PreparedFrameMetadata, SourceItem
+
+
+def test_resolve_original_sample_uses_prepared_frame_metadata_shape() -> None:
+    engine = object.__new__(YOLOEEngine)
+    metadata = PreparedFrameMetadata(original_shape=(720, 1280), path="camera_frame000001")
+
+    sample = engine._resolve_original_sample(metadata, None, (320, 320))
+
+    assert sample.path == "camera_frame000001"
+    assert sample.original.shape == (720, 1280, 3)
+
+
+def test_resolve_original_sample_prefers_prepared_frame_preview() -> None:
+    engine = object.__new__(YOLOEEngine)
+    preview = torch.zeros((5, 7, 3), dtype=torch.uint8).numpy()
+    metadata = PreparedFrameMetadata(original_shape=(5, 7), path="camera_frame000002", preview_image=preview)
+
+    sample = engine._resolve_original_sample(metadata, None, (320, 320))
+
+    assert sample.path == "camera_frame000002"
+    assert sample.original is preview
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required for prepared-tensor stream handoff tests")

--- a/tests/test_gstreamer.py
+++ b/tests/test_gstreamer.py
@@ -1,11 +1,17 @@
 from __future__ import annotations
 
+import pytest
+import torch
 from yoloe_tensorrt import (
+    JetsonZeroCopySource,
     build_dummy_video_pipeline,
     build_rtsp_pipeline,
     build_usb_camera_pipeline,
+    build_zero_copy_rtsp_pipeline,
+    build_zero_copy_usb_camera_pipeline,
     camera_source_from_spec,
 )
+from yoloe_tensorrt.inputs import PreparedTensorInput
 
 
 def test_build_usb_camera_pipeline_defaults_to_mjpeg_bgr_appsink() -> None:
@@ -64,6 +70,24 @@ def test_build_rtsp_pipeline_preserves_credentials_and_query() -> None:
     assert "videoscale" not in pipeline
     assert "videorate" not in pipeline
     assert "video/x-raw,format=BGR" in pipeline
+
+
+def test_build_zero_copy_usb_camera_pipeline_targets_nvmm_bgrx() -> None:
+    pipeline = build_zero_copy_usb_camera_pipeline("/dev/video0", width=640, height=480, fps=30)
+
+    assert "v4l2src device=/dev/video0" in pipeline
+    assert "nvv4l2decoder" in pipeline
+    assert "video/x-raw(memory:NVMM),format=BGRx" in pipeline
+    assert "appsink name=sink" in pipeline
+
+
+def test_build_zero_copy_rtsp_pipeline_targets_nvmm_bgrx() -> None:
+    pipeline = build_zero_copy_rtsp_pipeline("rtsp://camera.local/stream", width=1280, height=720, fps=30)
+
+    assert 'uridecodebin uri="rtsp://camera.local/stream" use-buffering=false' in pipeline
+    assert "nvvidconv" in pipeline
+    assert "video/x-raw(memory:NVMM),format=BGRx,width=1280,height=720,framerate=30/1" in pipeline
+    assert "appsink name=sink" in pipeline
 
 
 def test_camera_source_from_spec_supports_dummy_alias() -> None:
@@ -132,3 +156,96 @@ def test_camera_source_from_spec_keeps_explicit_rtspsrc_pipeline_literal() -> No
 
     assert source.prefix == "manual"
     assert source.pipeline == pipeline
+
+
+def test_camera_source_from_spec_uses_zero_copy_source_when_requested(monkeypatch, tmp_path) -> None:
+    device_path = tmp_path / "video0"
+    device_path.touch()
+    monkeypatch.setattr("yoloe_tensorrt.gstreamer.JETSON_ZERO_COPY_AVAILABLE", True)
+
+    source = camera_source_from_spec(
+        device_path,
+        prefix="camera",
+        zero_copy=True,
+        target_imgsz=640,
+        fp16=True,
+    )
+
+    assert isinstance(source, JetsonZeroCopySource)
+    assert source.prefix == "camera"
+    assert source.target_imgsz == (640, 640)
+    assert source.fp16 is True
+    assert source.required is True
+    assert source.fallback_source is None
+
+
+def test_camera_source_from_spec_auto_zero_copy_keeps_cpu_fallback(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    device_path = tmp_path / "video0"
+    device_path.touch()
+    monkeypatch.setattr("yoloe_tensorrt.gstreamer.JETSON_ZERO_COPY_AVAILABLE", True)
+
+    source = camera_source_from_spec(
+        device_path,
+        prefix="camera",
+        target_imgsz=(320, 320),
+    )
+
+    assert isinstance(source, JetsonZeroCopySource)
+    assert source.fallback_source is not None
+
+
+def test_camera_source_from_spec_zero_copy_requires_target_imgsz(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    device_path = tmp_path / "video0"
+    device_path.touch()
+    monkeypatch.setattr("yoloe_tensorrt.gstreamer.JETSON_ZERO_COPY_AVAILABLE", True)
+
+    with pytest.raises(ValueError, match="target_imgsz"):
+        camera_source_from_spec(device_path, zero_copy=True)
+
+
+def test_jetson_zero_copy_source_yields_prepared_tensor_inputs(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _FakeNativeSource:
+        def __init__(self) -> None:
+            self.closed = False
+            self.calls = 0
+
+        def read_frame(self):
+            if self.calls >= 1:
+                return None
+            self.calls += 1
+            return {
+                "tensor": torch.zeros((1, 3, 320, 320), dtype=torch.float32),
+                "path": "zc_frame000000",
+                "original_shape": (480, 640),
+                "producer_stream": 0,
+                "preview": torch.zeros((480, 640, 3), dtype=torch.uint8).numpy(),
+            }
+
+        def close(self) -> None:
+            self.closed = True
+
+    fake_source = _FakeNativeSource()
+    monkeypatch.setattr(
+        "yoloe_tensorrt.gstreamer.build_native_jetson_camera_source",
+        lambda *args, **kwargs: fake_source,
+    )
+
+    source = JetsonZeroCopySource(
+        pipeline="fake-pipeline",
+        prefix="zc",
+        target_imgsz=(320, 320),
+        fp16=False,
+        preview_cpu=True,
+        max_frames=1,
+    )
+
+    items = list(source)
+    assert len(items) == 1
+    item = items[0]
+
+    assert isinstance(item, PreparedTensorInput)
+    assert tuple(int(v) for v in item.tensor.shape) == (1, 3, 320, 320)
+    assert item.path == "zc_frame000000"
+    assert item.original_image.original_shape == (480, 640)
+    assert item.original_image.preview_image.shape == (480, 640, 3)
+    assert fake_source.closed is True

--- a/yoloe_tensorrt/__init__.py
+++ b/yoloe_tensorrt/__init__.py
@@ -8,8 +8,11 @@ __all__ = [
     "export_model",
     "configure_logging",
     "GStreamerSource",
+    "JetsonZeroCopySource",
     "build_usb_camera_pipeline",
+    "build_zero_copy_usb_camera_pipeline",
     "build_rtsp_pipeline",
+    "build_zero_copy_rtsp_pipeline",
     "build_dummy_video_pipeline",
     "camera_source_from_spec",
     "run_camera_gui",
@@ -43,14 +46,26 @@ def __getattr__(name: str):
         from .gstreamer import GStreamerSource
 
         return GStreamerSource
+    if name == "JetsonZeroCopySource":
+        from .gstreamer import JetsonZeroCopySource
+
+        return JetsonZeroCopySource
     if name == "build_usb_camera_pipeline":
         from .gstreamer import build_usb_camera_pipeline
 
         return build_usb_camera_pipeline
+    if name == "build_zero_copy_usb_camera_pipeline":
+        from .gstreamer import build_zero_copy_usb_camera_pipeline
+
+        return build_zero_copy_usb_camera_pipeline
     if name == "build_rtsp_pipeline":
         from .gstreamer import build_rtsp_pipeline
 
         return build_rtsp_pipeline
+    if name == "build_zero_copy_rtsp_pipeline":
+        from .gstreamer import build_zero_copy_rtsp_pipeline
+
+        return build_zero_copy_rtsp_pipeline
     if name == "build_dummy_video_pipeline":
         from .gstreamer import build_dummy_video_pipeline
 

--- a/yoloe_tensorrt/engine.py
+++ b/yoloe_tensorrt/engine.py
@@ -31,7 +31,7 @@ from .prompts import (
     load_prompt_projector,
     resolve_text_asset_path,
 )
-from .source import SourceItem, normalize_source
+from .source import PreparedFrameMetadata, SourceItem, normalize_source
 from .tracking import DEFAULT_TRACKER, YOLOETrackerSession
 from .trt import TensorRTRuntime
 
@@ -452,12 +452,18 @@ class YOLOEEngine:
 
     def _resolve_original_sample(
         self,
-        original_image: SourceItem | object | None,
+        original_image: SourceItem | PreparedFrameMetadata | object | None,
         path: str | None,
         input_shape: tuple[int, int],
     ) -> SimpleNamespace:
         if isinstance(original_image, SourceItem):
             return SimpleNamespace(original=original_image.image, path=path or original_image.path)
+        if isinstance(original_image, PreparedFrameMetadata):
+            resolved_path = path or original_image.path or "tensor0"
+            if original_image.preview_image is not None:
+                return SimpleNamespace(original=original_image.preview_image, path=resolved_path)
+            fallback_image = np.zeros((*original_image.original_shape, 3), dtype=np.uint8)
+            return SimpleNamespace(original=fallback_image, path=resolved_path)
         if original_image is not None:
             item = normalize_source(original_image, default_prefix="tensor")[0]
             return SimpleNamespace(original=item.image, path=path or item.path)
@@ -583,18 +589,17 @@ class YOLOEEngine:
 
     def predict_item(
         self,
-        item: SourceItem,
+        item: InferenceSourceItem,
         imgsz: int | tuple[int, int] | list[int] | None = None,
         conf: float = 0.25,
         iou: float = 0.45,
         max_det: int | None = None,
         retina_masks: bool = False,
     ) -> Results:
-        target_size = normalize_imgsz(imgsz or self.metadata.default_imgsz)
         resolved_max_det = int(max_det or self.metadata.max_det)
-        return self._predict_one(
+        return self._predict_input_entry(
             item=item,
-            imgsz=target_size,
+            imgsz=imgsz,
             conf=conf,
             iou=iou,
             max_det=resolved_max_det,

--- a/yoloe_tensorrt/gstreamer.py
+++ b/yoloe_tensorrt/gstreamer.py
@@ -4,9 +4,12 @@ from dataclasses import dataclass
 from pathlib import Path
 
 import numpy as np
+from torch.utils.dlpack import from_dlpack
 
 from .logging_utils import get_logger
-from .source import SourceItem, SourceStream
+from .native_backend import JETSON_ZERO_COPY_AVAILABLE, build_native_jetson_camera_source
+from .preprocess import normalize_imgsz
+from .source import PreparedFrameMetadata, SourceItem, SourceStream
 
 LOGGER = get_logger(__name__)
 
@@ -90,6 +93,43 @@ def build_usb_camera_pipeline(
     return pipeline
 
 
+def build_zero_copy_usb_camera_pipeline(
+    device: str | Path = "/dev/video0",
+    width: int | None = None,
+    height: int | None = None,
+    fps: int | None = None,
+    prefer_mjpeg: bool = True,
+    io_mode: str = "mmap",
+    appsink_name: str = "sink",
+) -> str:
+    device_path = str(Path(device))
+    source = f"v4l2src device={device_path} io-mode={io_mode} do-timestamp=true"
+    caps_parts: list[str] = []
+    if width is not None:
+        caps_parts.append(f"width={int(width)}")
+    if height is not None:
+        caps_parts.append(f"height={int(height)}")
+    if fps is not None:
+        caps_parts.append(f"framerate={int(fps)}/1")
+
+    if prefer_mjpeg:
+        source_caps = "image/jpeg"
+        decode = "jpegparse ! nvv4l2decoder mjpeg=true enable-max-performance=true"
+    else:
+        source = f"nvv4l2camerasrc device={device_path} do-timestamp=true"
+        source_caps = "video/x-raw(memory:NVMM),format=UYVY"
+        decode = "nvvidconv"
+
+    if caps_parts:
+        source_caps += "," + ",".join(caps_parts)
+
+    return (
+        f"{source} ! {source_caps} ! {decode} ! "
+        f"video/x-raw(memory:NVMM),format=BGRx ! "
+        f"appsink name={appsink_name} emit-signals=false max-buffers=1 drop=true sync=false"
+    )
+
+
 def build_rtsp_pipeline(
     uri: str,
     width: int | None = None,
@@ -120,6 +160,29 @@ def build_rtsp_pipeline(
     return pipeline
 
 
+def build_zero_copy_rtsp_pipeline(
+    uri: str,
+    width: int | None = None,
+    height: int | None = None,
+    fps: int | None = None,
+    appsink_name: str = "sink",
+) -> str:
+    caps = ["video/x-raw(memory:NVMM),format=BGRx"]
+    if width is not None:
+        caps.append(f"width={int(width)}")
+    if height is not None:
+        caps.append(f"height={int(height)}")
+    if fps is not None:
+        caps.append(f"framerate={int(fps)}/1")
+    return (
+        f"uridecodebin uri={_gst_quote(str(uri).strip())} use-buffering=false ! "
+        "queue max-size-buffers=1 max-size-bytes=0 max-size-time=0 leaky=downstream ! "
+        "nvvidconv ! "
+        f"{','.join(caps)} ! "
+        f"appsink name={appsink_name} emit-signals=false max-buffers=1 drop=true sync=false"
+    )
+
+
 def build_dummy_video_pipeline(
     width: int = 640,
     height: int = 480,
@@ -145,14 +208,22 @@ def camera_source_from_spec(
     timeout_s: float = 5.0,
     prefix: str = "camera",
     max_frames: int | None = None,
-) -> GStreamerSource:
+    zero_copy: bool | None = None,
+    preview_cpu: bool = False,
+    target_imgsz: int | tuple[int, int] | list[int] | None = None,
+    fp16: bool = False,
+    device: str | int = "cuda:0",
+) -> SourceStream:
     source_text = str(source_value).strip()
     lowered = source_text.lower()
     resolved_width = 640 if width is None else int(width)
     resolved_height = 480 if height is None else int(height)
     resolved_fps = 30 if fps is None else int(fps)
+    fallback_source: SourceStream
+    zero_copy_pipeline: str | None = None
+    zero_copy_supported = False
     if is_rtsp_uri(source_text):
-        return GStreamerSource.rtsp(
+        fallback_source = GStreamerSource.rtsp(
             source_text,
             width=width,
             height=height,
@@ -161,17 +232,26 @@ def camera_source_from_spec(
             timeout_s=timeout_s,
             prefix=prefix,
         )
-    if "!" in source_text:
-        return GStreamerSource(
+        zero_copy_pipeline = build_zero_copy_rtsp_pipeline(
+            source_text,
+            width=width,
+            height=height,
+            fps=fps,
+        )
+        zero_copy_supported = True
+    elif "!" in source_text:
+        fallback_source = GStreamerSource(
             pipeline=source_text,
             prefix=prefix,
             max_frames=max_frames,
             timeout_s=timeout_s,
         )
-    if lowered in {"dummy", "videotest", "videotestsrc"} or lowered.startswith(("dummy://", "videotest://")):
+        zero_copy_pipeline = source_text
+        zero_copy_supported = True
+    elif lowered in {"dummy", "videotest", "videotestsrc"} or lowered.startswith(("dummy://", "videotest://")):
         pattern = source_text.split("://", 1)[1].strip() if "://" in source_text else "ball"
         pattern = pattern or "ball"
-        return GStreamerSource(
+        fallback_source = GStreamerSource(
             pipeline=build_dummy_video_pipeline(
                 width=resolved_width,
                 height=resolved_height,
@@ -182,18 +262,49 @@ def camera_source_from_spec(
             max_frames=max_frames,
             timeout_s=timeout_s,
         )
+    else:
+        device_path = Path(source_text)
+        if not device_path.exists():
+            raise FileNotFoundError(f"Camera source device is missing: {device_path}")
+        fallback_source = GStreamerSource.usb_camera(
+            device=device_path,
+            width=resolved_width,
+            height=resolved_height,
+            fps=resolved_fps,
+            max_frames=max_frames,
+            timeout_s=timeout_s,
+            prefix=prefix,
+        )
+        zero_copy_pipeline = build_zero_copy_usb_camera_pipeline(
+            device=device_path,
+            width=width,
+            height=height,
+            fps=fps,
+        )
+        zero_copy_supported = True
 
-    device_path = Path(source_text)
-    if not device_path.exists():
-        raise FileNotFoundError(f"Camera source device is missing: {device_path}")
-    return GStreamerSource.usb_camera(
-        device=device_path,
-        width=resolved_width,
-        height=resolved_height,
-        fps=resolved_fps,
+    if zero_copy is False or not zero_copy_supported:
+        return fallback_source
+    if target_imgsz is None:
+        if zero_copy is True:
+            raise ValueError("zero_copy camera sources require target_imgsz so frames can be prepared for inference")
+        return fallback_source
+    if not JETSON_ZERO_COPY_AVAILABLE:
+        if zero_copy is True:
+            raise RuntimeError("Jetson zero-copy camera ingest is unavailable in the current native build")
+        return fallback_source
+
+    return JetsonZeroCopySource(
+        pipeline=str(zero_copy_pipeline),
+        prefix=prefix,
+        target_imgsz=normalize_imgsz(target_imgsz),
+        fp16=bool(fp16),
+        preview_cpu=preview_cpu,
         max_frames=max_frames,
         timeout_s=timeout_s,
-        prefix=prefix,
+        device=device,
+        fallback_source=None if zero_copy else fallback_source,
+        required=bool(zero_copy),
     )
 
 
@@ -316,6 +427,82 @@ class GStreamerSource(SourceStream):
             pipeline.get_state(self.timeout_ns)
             pipeline = None
             LOGGER.info("Closed GStreamer source '%s'", self.prefix)
+
+
+@dataclass
+class JetsonZeroCopySource(SourceStream):
+    pipeline: str
+    prefix: str
+    target_imgsz: tuple[int, int]
+    fp16: bool
+    preview_cpu: bool = False
+    max_frames: int | None = None
+    timeout_s: float = 5.0
+    device: str | int = "cuda:0"
+    fallback_source: SourceStream | None = None
+    required: bool = False
+    is_live_source: bool = True
+
+    def __iter__(self):
+        from .inputs import PreparedTensorInput
+
+        native_source = build_native_jetson_camera_source(
+            self.pipeline,
+            prefix=self.prefix,
+            timeout_s=self.timeout_s,
+            target_h=int(self.target_imgsz[0]),
+            target_w=int(self.target_imgsz[1]),
+            fp16=self.fp16,
+            preview_cpu=self.preview_cpu,
+            device=self.device,
+        )
+        if native_source is None:
+            if self.fallback_source is not None and not self.required:
+                LOGGER.info(
+                    "Zero-copy camera backend unavailable for '%s'; falling back to CPU appsink path",
+                    self.prefix,
+                )
+                yield from self.fallback_source
+                return
+            raise RuntimeError("Jetson zero-copy camera ingest is unavailable in the current native build")
+
+        LOGGER.info("Opening Jetson zero-copy source '%s' with pipeline: %s", self.prefix, self.pipeline)
+        frame_index = 0
+        yielded_any = False
+        try:
+            while self.max_frames is None or frame_index < self.max_frames:
+                frame = native_source.read_frame()
+                if frame is None:
+                    break
+                yielded_any = True
+                path = str(frame["path"])
+                preview_image = frame.get("preview")
+                metadata = PreparedFrameMetadata(
+                    original_shape=tuple(int(v) for v in frame["original_shape"]),
+                    path=path,
+                    preview_image=preview_image,
+                )
+                yield PreparedTensorInput(
+                    tensor=from_dlpack(frame["tensor"]),
+                    path=path,
+                    original_image=metadata,
+                    producer_stream=int(frame["producer_stream"]),
+                )
+                frame_index += 1
+        except Exception:
+            native_source.close()
+            if not yielded_any and self.fallback_source is not None and not self.required:
+                LOGGER.warning(
+                    "Zero-copy startup failed for '%s'; falling back to CPU appsink path",
+                    self.prefix,
+                    exc_info=True,
+                )
+                yield from self.fallback_source
+                return
+            raise
+        finally:
+            native_source.close()
+            LOGGER.info("Closed Jetson zero-copy source '%s'", self.prefix)
 
 
 def _sample_to_bgr(sample, GstVideo) -> np.ndarray:

--- a/yoloe_tensorrt/gui.py
+++ b/yoloe_tensorrt/gui.py
@@ -457,6 +457,11 @@ def run_camera_gui(
                 timeout_s=timeout_s,
                 prefix=prefix,
                 max_frames=max_frames,
+                zero_copy=None,
+                preview_cpu=True,
+                target_imgsz=target_size,
+                fp16=engine._main_fp16,
+                device=engine.device,
             )
 
         make_source = _make_source

--- a/yoloe_tensorrt/inputs.py
+++ b/yoloe_tensorrt/inputs.py
@@ -12,6 +12,7 @@ from PIL import Image
 from .gstreamer import camera_source_from_spec, is_rtsp_uri
 from .logging_utils import get_logger
 from .source import (
+    PreparedFrameMetadata,
     SourceItem,
     SourceStream,
     _is_iterable_source,
@@ -31,7 +32,7 @@ InputHint = Literal["auto", "raw", "prepared"]
 class PreparedTensorInput:
     tensor: torch.Tensor
     path: str
-    original_image: SourceItem | object | None = None
+    original_image: SourceItem | PreparedFrameMetadata | object | None = None
     producer_stream: int | None = None
 
     def __post_init__(self) -> None:

--- a/yoloe_tensorrt/native_backend.py
+++ b/yoloe_tensorrt/native_backend.py
@@ -8,14 +8,21 @@ from .logging_utils import get_logger
 LOGGER = get_logger(__name__)
 
 try:
-    from ._native import NativeMainRuntime
+    from . import _native as _native_module
+
+    NativeMainRuntime = _native_module.NativeMainRuntime  # type: ignore[attr-defined]
+    NativeJetsonCameraSource = getattr(_native_module, "NativeJetsonCameraSource", None)
 
     NATIVE_AVAILABLE = os.environ.get("YOLOE_TRT_DISABLE_NATIVE", "").lower() not in {"1", "true", "yes"}
     NATIVE_IMPORT_ERROR: Exception | None = None
 except Exception as exc:  # pragma: no cover - import surface depends on local build/runtime libs
     NativeMainRuntime = None  # type: ignore[assignment]
+    NativeJetsonCameraSource = None  # type: ignore[assignment]
     NATIVE_AVAILABLE = False
     NATIVE_IMPORT_ERROR = exc
+
+
+JETSON_ZERO_COPY_AVAILABLE = bool(NATIVE_AVAILABLE and NativeJetsonCameraSource is not None)
 
 
 def build_native_main_runtime(
@@ -42,3 +49,43 @@ def build_native_main_runtime(
             device_id = 0
 
     return NativeMainRuntime(str(engine_path), image_input_name, prompt_input_name, device_id)
+
+
+def build_native_jetson_camera_source(
+    pipeline: str,
+    *,
+    prefix: str,
+    timeout_s: float,
+    target_h: int,
+    target_w: int,
+    fp16: bool,
+    preview_cpu: bool = False,
+    device: str | int = "cuda:0",
+):
+    if not NATIVE_AVAILABLE or NativeJetsonCameraSource is None:
+        if NATIVE_IMPORT_ERROR is not None:
+            LOGGER.info("Native Jetson camera backend unavailable: %s", NATIVE_IMPORT_ERROR)
+        return None
+
+    if isinstance(device, int):
+        device_id = device
+    else:
+        device_str = str(device)
+        if not device_str.startswith("cuda"):
+            LOGGER.info("Native Jetson camera backend disabled for non-CUDA device '%s'", device_str)
+            return None
+        if ":" in device_str:
+            device_id = int(device_str.split(":", 1)[1])
+        else:
+            device_id = 0
+
+    return NativeJetsonCameraSource(
+        pipeline,
+        prefix,
+        float(timeout_s),
+        int(target_h),
+        int(target_w),
+        bool(fp16),
+        bool(preview_cpu),
+        device_id,
+    )

--- a/yoloe_tensorrt/source.py
+++ b/yoloe_tensorrt/source.py
@@ -19,6 +19,29 @@ class SourceItem:
     path: str
 
 
+@dataclass(frozen=True)
+class PreparedFrameMetadata:
+    original_shape: tuple[int, int]
+    path: str | None = None
+    preview_image: np.ndarray | None = None
+
+    def __post_init__(self) -> None:
+        height = int(self.original_shape[0])
+        width = int(self.original_shape[1])
+        object.__setattr__(self, "original_shape", (height, width))
+        if height <= 0 or width <= 0:
+            raise ValueError("Prepared frame metadata requires a positive (height, width) original_shape")
+        if self.preview_image is not None:
+            if self.preview_image.ndim != 3 or int(self.preview_image.shape[2]) != 3:
+                raise ValueError("Prepared frame preview_image must be a BGR image with shape (H, W, 3)")
+            preview_shape = (int(self.preview_image.shape[0]), int(self.preview_image.shape[1]))
+            if preview_shape != self.original_shape:
+                raise ValueError(
+                    "Prepared frame preview_image shape must match original_shape; "
+                    f"got preview={preview_shape} original_shape={self.original_shape}"
+                )
+
+
 class SourceStream(Iterable[SourceItem]):
     is_live_source: bool = False
     max_frames: int | None = None


### PR DESCRIPTION
- Added a Jetson zero-copy camera backend in src/native/main.cpp using NVMM/EGL/CUDA interop with GPU-side pack/letterbox preprocess.
- Extended native build/configuration in CMakeLists.txt to detect and compile the Jetson camera path only when the required CUDA, EGL, GStreamer allocator, and NvBufSurface pieces are available.
- Introduced Python-side zero-copy source routing in yoloe_tensorrt/gstreamer.py with zero_copy=None|True|False, automatic fallback to the existing CPU appsink path, and first-class RTSP URL support.
- Added prepared frame metadata handling in yoloe_tensorrt/source.py and yoloe_tensorrt/engine.py so zero-copy frames keep correct original-shape information without requiring a CPU image on the headless path.
- Updates the GUI in yoloe_tensorrt/gui.py to request zero-copy automatically when available while still allowing CPU preview frames for rendering overlays.