### PR TITLE
perf: move visual prompt runtime into native backend

### DIFF
--- a/src/native/main.cpp
+++ b/src/native/main.cpp
@@ -257,7 +257,7 @@ class NativeJetsonCameraSource;
 #endif
 
 struct ManagedTensorContext {
-    std::shared_ptr<NativeMainRuntime> owner;
+    std::shared_ptr<void> owner;
     std::shared_ptr<class PendingPostprocessOutputs> pending_postprocess_outputs;
     std::vector<std::int64_t> shape;
     DLDataType dtype{};
@@ -278,6 +278,13 @@ struct NativePostprocessResult {
     int mask_height = 0;
     int mask_width = 0;
     bool include_masks = false;
+};
+
+struct VisualPromptHostBatch {
+    std::vector<float> tensor;
+    int prompt_count = 0;
+    int prompt_height = 0;
+    int prompt_width = 0;
 };
 
 inline cudaStream_t parse_dlpack_consumer_stream(py::object const& stream)
@@ -600,10 +607,180 @@ inline bool threshold_mask(std::vector<float> const& src, std::vector<std::uint8
     return any;
 }
 
+inline std::vector<int> parse_visual_categories(
+    py::array_t<std::int32_t, py::array::c_style | py::array::forcecast> const& category_py)
+{
+    auto const info = category_py.request();
+    if (info.ndim != 1) {
+        throw std::runtime_error("visual prompt categories must have shape (N,)");
+    }
+    auto const count = static_cast<std::size_t>(info.shape[0]);
+    auto const* src = static_cast<std::int32_t const*>(info.ptr);
+    std::vector<int> categories(count);
+    int max_category = -1;
+    for (std::size_t index = 0; index < count; ++index) {
+        if (src[index] < 0) {
+            throw std::runtime_error("visual prompt categories must be non-negative");
+        }
+        categories[index] = static_cast<int>(src[index]);
+        max_category = std::max(max_category, categories[index]);
+    }
+    if (count == 0 || max_category < 0) {
+        throw std::runtime_error("visual prompt categories must not be empty");
+    }
+    return categories;
+}
+
+inline void validate_visual_prompt_count(std::size_t prompt_count, std::vector<int> const& categories)
+{
+    if (prompt_count != categories.size()) {
+        throw std::runtime_error("visual prompt categories must match the number of prompts");
+    }
+}
+
+inline std::pair<float, float> compute_visual_prompt_letterbox_padding(
+    int src_h,
+    int src_w,
+    int dst_h,
+    int dst_w)
+{
+    float const gain = std::min(static_cast<float>(dst_h) / static_cast<float>(src_h), static_cast<float>(dst_w) / static_cast<float>(src_w));
+    float const pad_x = std::round((static_cast<float>(dst_w) - std::round(static_cast<float>(src_w) * gain)) / 2.0f - 0.1f);
+    float const pad_y = std::round((static_cast<float>(dst_h) - std::round(static_cast<float>(src_h) * gain)) / 2.0f - 0.1f);
+    return { pad_x, pad_y };
+}
+
+inline VisualPromptHostBatch build_visual_prompt_batch_from_boxes(
+    py::array_t<float, py::array::c_style | py::array::forcecast> const& boxes_py,
+    std::vector<int> const& categories,
+    int src_h,
+    int src_w,
+    int dst_h,
+    int dst_w,
+    int visual_stride)
+{
+    auto const info = boxes_py.request();
+    if (info.ndim != 2 || info.shape[1] != 4) {
+        throw std::runtime_error("visual prompt bboxes must have shape (N, 4)");
+    }
+    auto const prompt_count = static_cast<std::size_t>(info.shape[0]);
+    validate_visual_prompt_count(prompt_count, categories);
+
+    int const prompt_height = dst_h / visual_stride;
+    int const prompt_width = dst_w / visual_stride;
+    int const unique_prompt_count = *std::max_element(categories.begin(), categories.end()) + 1;
+
+    VisualPromptHostBatch batch;
+    batch.prompt_count = unique_prompt_count;
+    batch.prompt_height = prompt_height;
+    batch.prompt_width = prompt_width;
+    batch.tensor.assign(
+        static_cast<std::size_t>(unique_prompt_count) * static_cast<std::size_t>(prompt_height) * static_cast<std::size_t>(prompt_width),
+        0.0f);
+
+    float const gain = std::min(static_cast<float>(dst_h) / static_cast<float>(src_h), static_cast<float>(dst_w) / static_cast<float>(src_w));
+    auto const [pad_x, pad_y] = compute_visual_prompt_letterbox_padding(src_h, src_w, dst_h, dst_w);
+    auto const* boxes = static_cast<float const*>(info.ptr);
+
+    for (std::size_t index = 0; index < prompt_count; ++index) {
+        float const x1 = ((boxes[(index * 4) + 0] * gain) + pad_x) / static_cast<float>(visual_stride);
+        float const y1 = ((boxes[(index * 4) + 1] * gain) + pad_y) / static_cast<float>(visual_stride);
+        float const x2 = ((boxes[(index * 4) + 2] * gain) + pad_x) / static_cast<float>(visual_stride);
+        float const y2 = ((boxes[(index * 4) + 3] * gain) + pad_y) / static_cast<float>(visual_stride);
+
+        int const left = std::max(0, std::min(prompt_width, static_cast<int>(std::ceil(x1))));
+        int const top = std::max(0, std::min(prompt_height, static_cast<int>(std::ceil(y1))));
+        int const right = std::max(0, std::min(prompt_width, static_cast<int>(std::ceil(x2))));
+        int const bottom = std::max(0, std::min(prompt_height, static_cast<int>(std::ceil(y2))));
+        if (left >= right || top >= bottom) {
+            continue;
+        }
+
+        auto const plane_offset =
+            static_cast<std::size_t>(categories[index]) * static_cast<std::size_t>(prompt_height) * static_cast<std::size_t>(prompt_width);
+        for (int y = top; y < bottom; ++y) {
+            auto* row = batch.tensor.data() + plane_offset + static_cast<std::size_t>(y * prompt_width);
+            std::fill(row + left, row + right, 1.0f);
+        }
+    }
+
+    return batch;
+}
+
+inline cv::Mat letterbox_mask_nearest(cv::Mat const& src, int dst_h, int dst_w)
+{
+    float const gain = std::min(static_cast<float>(dst_h) / static_cast<float>(src.rows), static_cast<float>(dst_w) / static_cast<float>(src.cols));
+    int const resized_w = std::max(1, static_cast<int>(std::round(static_cast<float>(src.cols) * gain)));
+    int const resized_h = std::max(1, static_cast<int>(std::round(static_cast<float>(src.rows) * gain)));
+
+    cv::Mat resized;
+    cv::resize(src, resized, cv::Size(resized_w, resized_h), 0.0, 0.0, cv::INTER_NEAREST);
+
+    float const dw = static_cast<float>(dst_w - resized_w) / 2.0f;
+    float const dh = static_cast<float>(dst_h - resized_h) / 2.0f;
+    int const top = std::round(dh - 0.1f);
+    int const bottom = std::round(dh + 0.1f);
+    int const left = std::round(dw - 0.1f);
+    int const right = std::round(dw + 0.1f);
+
+    cv::Mat output;
+    cv::copyMakeBorder(resized, output, top, bottom, left, right, cv::BORDER_CONSTANT, cv::Scalar(0));
+    return output;
+}
+
+inline VisualPromptHostBatch build_visual_prompt_batch_from_masks(
+    py::array_t<std::uint8_t, py::array::c_style | py::array::forcecast> const& masks_py,
+    std::vector<int> const& categories,
+    int dst_h,
+    int dst_w,
+    int visual_stride)
+{
+    auto const info = masks_py.request();
+    if (info.ndim != 3) {
+        throw std::runtime_error("visual prompt masks must have shape (N, H, W)");
+    }
+    auto const prompt_count = static_cast<std::size_t>(info.shape[0]);
+    validate_visual_prompt_count(prompt_count, categories);
+
+    int const src_h = static_cast<int>(info.shape[1]);
+    int const src_w = static_cast<int>(info.shape[2]);
+    int const prompt_height = dst_h / visual_stride;
+    int const prompt_width = dst_w / visual_stride;
+    int const unique_prompt_count = *std::max_element(categories.begin(), categories.end()) + 1;
+
+    VisualPromptHostBatch batch;
+    batch.prompt_count = unique_prompt_count;
+    batch.prompt_height = prompt_height;
+    batch.prompt_width = prompt_width;
+    batch.tensor.assign(
+        static_cast<std::size_t>(unique_prompt_count) * static_cast<std::size_t>(prompt_height) * static_cast<std::size_t>(prompt_width),
+        0.0f);
+
+    auto const* src = static_cast<std::uint8_t const*>(info.ptr);
+    auto const mask_plane = static_cast<std::size_t>(src_h) * static_cast<std::size_t>(src_w);
+    for (std::size_t index = 0; index < prompt_count; ++index) {
+        cv::Mat const mask(src_h, src_w, CV_8UC1, const_cast<std::uint8_t*>(src + (index * mask_plane)));
+        cv::Mat const letterboxed = letterbox_mask_nearest(mask, dst_h, dst_w);
+        cv::Mat resized;
+        cv::resize(letterboxed, resized, cv::Size(prompt_width, prompt_height), 0.0, 0.0, cv::INTER_NEAREST);
+        auto const plane_offset =
+            static_cast<std::size_t>(categories[index]) * static_cast<std::size_t>(prompt_height) * static_cast<std::size_t>(prompt_width);
+        for (int y = 0; y < prompt_height; ++y) {
+            auto const* row = resized.ptr<std::uint8_t>(y);
+            auto* dst_row = batch.tensor.data() + plane_offset + static_cast<std::size_t>(y * prompt_width);
+            for (int x = 0; x < prompt_width; ++x) {
+                dst_row[x] = (dst_row[x] != 0.0f || row[x] != 0U) ? 1.0f : 0.0f;
+            }
+        }
+    }
+
+    return batch;
+}
+
 class CudaTensorView {
 public:
     CudaTensorView(
-        std::shared_ptr<NativeMainRuntime> owner,
+        std::shared_ptr<void> owner,
         std::shared_ptr<PendingPostprocessOutputs> pending_postprocess_outputs,
         void* ptr,
         std::vector<std::int64_t> shape,
@@ -620,7 +797,7 @@ public:
     }
 
     CudaTensorView(
-        std::shared_ptr<NativeMainRuntime> owner,
+        std::shared_ptr<void> owner,
         std::shared_ptr<PendingPostprocessOutputs> pending_postprocess_outputs,
         void* ptr,
         std::vector<std::int64_t> shape,
@@ -675,7 +852,7 @@ public:
     }
 
 private:
-    std::shared_ptr<NativeMainRuntime> owner_;
+    std::shared_ptr<void> owner_;
     std::shared_ptr<PendingPostprocessOutputs> pending_postprocess_outputs_;
     void* ptr_ = nullptr;
     std::vector<std::int64_t> shape_;
@@ -850,6 +1027,11 @@ public:
         return fp16_;
     }
 
+    bool prompt_fp16() const
+    {
+        return prompt_binding_.dtype == nvinfer1::DataType::kHALF;
+    }
+
     void clear_prompt_embeddings()
     {
         has_prompt_embeddings_ = false;
@@ -908,6 +1090,41 @@ public:
 
         has_prompt_embeddings_ = true;
         current_prompt_count_ = static_cast<int>(prompt_count);
+    }
+
+    void set_prompt_embeddings_device(
+        std::uintptr_t prompt_embeddings_ptr_value,
+        int prompt_count,
+        int embed_dim,
+        std::uintptr_t producer_stream_value = 0)
+    {
+        if (prompt_embeddings_ptr_value == 0) {
+            throw std::runtime_error("prompt_embeddings pointer must not be null");
+        }
+        if (prompt_count < 0) {
+            throw std::runtime_error("prompt_count must be non-negative");
+        }
+        if (embed_dim != prompt_embed_dim_) {
+            throw std::runtime_error("prompt_embeddings embed dim does not match engine profile");
+        }
+
+        auto* prompt_embeddings_ptr = reinterpret_cast<void*>(prompt_embeddings_ptr_value);
+        auto* producer_stream = reinterpret_cast<cudaStream_t>(producer_stream_value);
+        activate_device("cudaSetDevice failed before device prompt upload");
+        wait_for_producer_stream(producer_stream);
+
+        auto const element_total = static_cast<std::size_t>(prompt_count) * static_cast<std::size_t>(embed_dim);
+        auto const bytes = element_total * dtype_size(prompt_binding_.dtype);
+        prompt_buffer_.ensure(std::max<std::size_t>(bytes, sizeof(float)));
+        if (bytes > 0) {
+            throw_if_cuda_failed(
+                cudaMemcpyAsync(prompt_buffer_.data(), prompt_embeddings_ptr, bytes, cudaMemcpyDeviceToDevice, stream_),
+                "cudaMemcpyAsync for device prompt embeddings failed");
+        }
+        throw_if_cuda_failed(cudaStreamSynchronize(stream_), "cudaStreamSynchronize failed after device prompt upload");
+
+        has_prompt_embeddings_ = true;
+        current_prompt_count_ = prompt_count;
     }
 
     py::dict infer_image(py::array image_py, int target_h, int target_w)
@@ -1823,6 +2040,501 @@ private:
     CudaEventHandle producer_handoff_event_;
 };
 
+class NativeVisualPromptRuntime : public std::enable_shared_from_this<NativeVisualPromptRuntime> {
+public:
+    NativeVisualPromptRuntime(
+        std::string engine_path,
+        std::string image_input_name,
+        std::string visual_input_name,
+        int visual_stride,
+        int device_id)
+        : engine_path_(std::move(engine_path))
+        , image_input_name_(std::move(image_input_name))
+        , visual_input_name_(std::move(visual_input_name))
+        , visual_stride_(visual_stride)
+        , device_id_(device_id)
+    {
+        try {
+            throw_if_cuda_failed(cudaSetDevice(device_id_), "cudaSetDevice failed");
+            throw_if_cuda_failed(cudaStreamCreate(&stream_), "cudaStreamCreate failed");
+            preprocess_start_event_.create("cudaEventCreate failed for visual preprocess start");
+            preprocess_end_event_.create("cudaEventCreate failed for visual preprocess end");
+            inference_start_event_.create("cudaEventCreate failed for visual inference start");
+            inference_end_event_.create("cudaEventCreate failed for visual inference end");
+
+            py::gil_scoped_release release;
+
+            std::FILE* file = std::fopen(engine_path_.c_str(), "rb");
+            if (file == nullptr) {
+                throw std::runtime_error("Failed to open TensorRT engine: " + engine_path_);
+            }
+            std::fseek(file, 0, SEEK_END);
+            auto const size = static_cast<std::size_t>(std::ftell(file));
+            std::rewind(file);
+            std::vector<char> bytes(size);
+            auto const read = std::fread(bytes.data(), 1, size, file);
+            std::fclose(file);
+            if (read != size) {
+                throw std::runtime_error("Failed to read TensorRT engine: " + engine_path_);
+            }
+
+            runtime_.reset(nvinfer1::createInferRuntime(logger_));
+            if (!runtime_) {
+                throw std::runtime_error("Failed to create TensorRT runtime");
+            }
+            engine_.reset(runtime_->deserializeCudaEngine(bytes.data(), bytes.size()));
+            if (!engine_) {
+                throw std::runtime_error("Failed to deserialize TensorRT engine");
+            }
+            context_.reset(engine_->createExecutionContext());
+            if (!context_) {
+                throw std::runtime_error("Failed to create TensorRT execution context");
+            }
+
+            discover_bindings();
+            image_input_index_ = find_binding_index(image_input_name_, true);
+            visual_input_index_ = find_binding_index(visual_input_name_, true);
+
+            image_binding_ = bindings_[static_cast<std::size_t>(image_input_index_)];
+            visual_binding_ = bindings_[static_cast<std::size_t>(visual_input_index_)];
+
+            if (image_binding_.dims.nbDims != 4) {
+                throw std::runtime_error("Visual image input must be NCHW");
+            }
+            if (visual_binding_.dims.nbDims != 4) {
+                throw std::runtime_error("Visual prompt input must have shape (1, N, H, W)");
+            }
+            if (output_indices_.empty()) {
+                throw std::runtime_error("Visual prompt runtime has no outputs");
+            }
+
+            fp16_ = image_binding_.dtype == nvinfer1::DataType::kHALF;
+        } catch (...) {
+            destroy_stream_noexcept();
+            throw;
+        }
+    }
+
+    ~NativeVisualPromptRuntime() noexcept
+    {
+        destroy_stream_noexcept();
+    }
+
+    std::vector<std::string> output_names() const
+    {
+        return output_names_;
+    }
+
+    bool fp16() const
+    {
+        return fp16_;
+    }
+
+    py::dict infer_image(
+        py::array image_py,
+        int target_h,
+        int target_w,
+        py::array_t<std::int32_t, py::array::c_style | py::array::forcecast> categories_py,
+        py::object bboxes = py::none(),
+        py::object masks = py::none())
+    {
+        auto image = py::array_t<std::uint8_t, py::array::c_style | py::array::forcecast>(image_py);
+        auto const info = image.request();
+        if (info.ndim != 3 || info.shape[2] != 3) {
+            throw std::runtime_error("image must have shape (H, W, 3)");
+        }
+
+        activate_device("cudaSetDevice failed before native visual inference");
+        auto const categories = parse_visual_categories(categories_py);
+        auto const visual_batch = build_visual_prompt_batch(categories, bboxes, masks, static_cast<int>(info.shape[0]), static_cast<int>(info.shape[1]), target_h, target_w);
+        preprocess_host_image(image, target_h, target_w);
+        upload_visual_prompt_batch(visual_batch);
+        auto const inference_ms = execute(image_buffer_.data(), visual_buffer_.data(), target_h, target_w, visual_batch.prompt_count);
+        auto const preprocess_ms = resolve_preprocess_ms();
+        return build_output_dict(target_h, target_w, preprocess_ms, inference_ms);
+    }
+
+    void warmup(int target_h, int target_w, int prompt_count, int runs = 2)
+    {
+        if (runs < 1) {
+            throw std::runtime_error("runs must be >= 1");
+        }
+        activate_device("cudaSetDevice failed before visual warmup");
+
+        py::array_t<std::uint8_t> image({ target_h, target_w, 3 });
+        {
+            auto mutable_image = image.mutable_unchecked<3>();
+            for (int y = 0; y < target_h; ++y) {
+                for (int x = 0; x < target_w; ++x) {
+                    mutable_image(y, x, 0) = 0;
+                    mutable_image(y, x, 1) = 0;
+                    mutable_image(y, x, 2) = 0;
+                }
+            }
+        }
+        py::array_t<std::int32_t> categories({ prompt_count });
+        {
+            auto mutable_categories = categories.mutable_unchecked<1>();
+            for (int index = 0; index < prompt_count; ++index) {
+                mutable_categories(index) = index;
+            }
+        }
+        py::array_t<float> bboxes({ prompt_count, 4 });
+        {
+            auto mutable_boxes = bboxes.mutable_unchecked<2>();
+            for (int index = 0; index < prompt_count; ++index) {
+                mutable_boxes(index, 0) = 0.0f;
+                mutable_boxes(index, 1) = 0.0f;
+                mutable_boxes(index, 2) = static_cast<float>(target_w);
+                mutable_boxes(index, 3) = static_cast<float>(target_h);
+            }
+        }
+        for (int run = 0; run < runs; ++run) {
+            static_cast<void>(infer_image(image, target_h, target_w, categories, bboxes, py::none()));
+        }
+    }
+
+private:
+    void destroy_stream_noexcept() noexcept
+    {
+        if (stream_ != nullptr) {
+            try {
+                cudaSetDevice(device_id_);
+                cudaStreamDestroy(stream_);
+            } catch (...) {
+            }
+            stream_ = nullptr;
+        }
+    }
+
+    void activate_device(char const* message) const
+    {
+        throw_if_cuda_failed(cudaSetDevice(device_id_), message);
+    }
+
+    double elapsed_event_ms(cudaEvent_t start_event, cudaEvent_t end_event, char const* context) const
+    {
+        float elapsed_ms = 0.0f;
+        throw_if_cuda_failed(
+            cudaEventElapsedTime(&elapsed_ms, start_event, end_event),
+            (std::string(context) + ": cudaEventElapsedTime failed").c_str());
+        return static_cast<double>(elapsed_ms);
+    }
+
+    VisualPromptHostBatch build_visual_prompt_batch(
+        std::vector<int> const& categories,
+        py::object const& bboxes_obj,
+        py::object const& masks_obj,
+        int src_h,
+        int src_w,
+        int dst_h,
+        int dst_w) const
+    {
+        if (!bboxes_obj.is_none()) {
+            auto const bboxes = py::array_t<float, py::array::c_style | py::array::forcecast>(bboxes_obj);
+            return build_visual_prompt_batch_from_boxes(bboxes, categories, src_h, src_w, dst_h, dst_w, visual_stride_);
+        }
+        if (!masks_obj.is_none()) {
+            auto const masks = py::array_t<std::uint8_t, py::array::c_style | py::array::forcecast>(masks_obj);
+            return build_visual_prompt_batch_from_masks(masks, categories, dst_h, dst_w, visual_stride_);
+        }
+        throw std::runtime_error("Either bboxes or masks must be provided");
+    }
+
+    void upload_visual_prompt_batch(VisualPromptHostBatch const& batch)
+    {
+        auto const element_total =
+            static_cast<std::size_t>(batch.prompt_count) * static_cast<std::size_t>(batch.prompt_height) * static_cast<std::size_t>(batch.prompt_width);
+        if (visual_binding_.dtype == nvinfer1::DataType::kHALF) {
+            visual_half_host_.resize(element_total);
+            for (std::size_t index = 0; index < element_total; ++index) {
+                visual_half_host_[index] = __float2half(batch.tensor[index]);
+            }
+            visual_buffer_.ensure(std::max<std::size_t>(visual_half_host_.size() * sizeof(__half), sizeof(__half)));
+            if (!visual_half_host_.empty()) {
+                throw_if_cuda_failed(
+                    cudaMemcpyAsync(
+                        visual_buffer_.data(),
+                        visual_half_host_.data(),
+                        visual_half_host_.size() * sizeof(__half),
+                        cudaMemcpyHostToDevice,
+                        stream_),
+                    "cudaMemcpyAsync failed for visual prompt upload");
+            }
+        } else {
+            visual_buffer_.ensure(std::max<std::size_t>(element_total * sizeof(float), sizeof(float)));
+            if (!batch.tensor.empty()) {
+                throw_if_cuda_failed(
+                    cudaMemcpyAsync(
+                        visual_buffer_.data(),
+                        batch.tensor.data(),
+                        batch.tensor.size() * sizeof(float),
+                        cudaMemcpyHostToDevice,
+                        stream_),
+                    "cudaMemcpyAsync failed for visual prompt upload");
+            }
+        }
+    }
+
+    double resolve_preprocess_ms() const
+    {
+#ifdef YOLOE_TRT_ENABLE_CUDA_PREPROCESS
+        return elapsed_event_ms(preprocess_start_event_, preprocess_end_event_, "visual host image preprocess");
+#else
+        return last_preprocess_cpu_ms_ + elapsed_event_ms(preprocess_start_event_, preprocess_end_event_, "visual host image upload");
+#endif
+    }
+
+    py::dict build_output_dict(int target_h, int target_w, double preprocess_ms, double inference_ms)
+    {
+        py::dict outputs;
+        for (std::size_t i = 0; i < output_indices_.size(); ++i) {
+            auto const binding_index = output_indices_[i];
+            auto const& binding = bindings_[binding_index];
+            outputs[py::str(binding.name)] = py::cast(
+                CudaTensorView(shared_from_this(), nullptr, output_buffers_[i].data(), output_shapes_[i], binding.dtype, device_id_));
+        }
+        outputs[py::str("input_shape")] = py::make_tuple(target_h, target_w);
+        outputs[py::str("preprocess_ms")] = preprocess_ms;
+        outputs[py::str("inference_ms")] = inference_ms;
+        return outputs;
+    }
+
+    int find_binding_index(std::string const& name, bool is_input) const
+    {
+        for (auto const& binding : bindings_) {
+            if (binding.name == name && binding.is_input == is_input) {
+                return binding.index;
+            }
+        }
+        throw std::runtime_error("Failed to locate TensorRT binding: " + name);
+    }
+
+    void discover_bindings()
+    {
+        auto const count = engine_->getNbIOTensors();
+        bindings_.reserve(static_cast<std::size_t>(count));
+        output_indices_.clear();
+        output_names_.clear();
+
+        for (int i = 0; i < count; ++i) {
+            BindingInfo binding;
+            binding.index = i;
+            binding.name = engine_->getIOTensorName(i);
+            binding.is_input = engine_->getTensorIOMode(binding.name.c_str()) == nvinfer1::TensorIOMode::kINPUT;
+            binding.dtype = engine_->getTensorDataType(binding.name.c_str());
+            binding.dims = engine_->getTensorShape(binding.name.c_str());
+            if (!binding.is_input) {
+                output_indices_.push_back(i);
+                output_names_.push_back(binding.name);
+            }
+            bindings_.push_back(binding);
+        }
+
+        output_buffers_.resize(output_indices_.size());
+        output_shapes_.resize(output_indices_.size());
+    }
+
+    void preprocess_host_image(py::array_t<std::uint8_t, py::array::c_style | py::array::forcecast> const& image, int target_h, int target_w)
+    {
+        auto const info = image.request();
+        auto const orig_h = static_cast<int>(info.shape[0]);
+        auto const orig_w = static_cast<int>(info.shape[1]);
+
+#ifdef YOLOE_TRT_ENABLE_CUDA_PREPROCESS
+        auto const input_bytes = static_cast<std::size_t>(orig_h) * static_cast<std::size_t>(info.strides[0]);
+        auto const plane_elements = static_cast<std::size_t>(target_h) * static_cast<std::size_t>(target_w) * 3U;
+        image_upload_buffer_.ensure(input_bytes);
+        image_buffer_.ensure(plane_elements * dtype_size(image_binding_.dtype));
+        throw_if_cuda_failed(cudaEventRecord(preprocess_start_event_, stream_), "cudaEventRecord failed for visual preprocess start");
+        throw_if_cuda_failed(
+            cudaMemcpyAsync(image_upload_buffer_.data(), info.ptr, input_bytes, cudaMemcpyHostToDevice, stream_),
+            "cudaMemcpyAsync for visual raw image upload failed");
+        launch_cuda_preprocess(
+            image_upload_buffer_.data(),
+            orig_w,
+            orig_h,
+            static_cast<int>(info.strides[0]),
+            CudaPreprocessInputFormat::kBGR,
+            target_w,
+            target_h,
+            fp16_,
+            image_buffer_.data(),
+            stream_);
+        throw_if_cuda_failed(cudaGetLastError(), "CUDA preprocess kernel launch failed for visual image");
+        throw_if_cuda_failed(cudaEventRecord(preprocess_end_event_, stream_), "cudaEventRecord failed for visual preprocess end");
+#else
+        auto const preprocess_start = Clock::now();
+        cv::Mat const src(orig_h, orig_w, CV_8UC3, const_cast<void*>(info.ptr));
+        auto const geometry = compute_letterbox_geometry(orig_w, orig_h, target_w, target_h);
+
+        cv::Mat resized;
+        cv::resize(src, resized, cv::Size(geometry.resized_width, geometry.resized_height), 0.0, 0.0, cv::INTER_LINEAR);
+        cv::Mat canvas(target_h, target_w, CV_8UC3, cv::Scalar(114, 114, 114));
+        resized.copyTo(canvas(cv::Rect(geometry.pad_left, geometry.pad_top, geometry.resized_width, geometry.resized_height)));
+
+        cv::Mat rgb;
+        cv::cvtColor(canvas, rgb, cv::COLOR_BGR2RGB);
+        cv::Mat rgb_f32;
+        rgb.convertTo(rgb_f32, CV_32FC3, 1.0 / 255.0);
+
+        std::vector<cv::Mat> channels;
+        cv::split(rgb_f32, channels);
+        auto const plane_elements = static_cast<std::size_t>(target_h) * static_cast<std::size_t>(target_w);
+        host_image_float_.resize(plane_elements * 3U);
+        for (int channel = 0; channel < 3; ++channel) {
+            std::memcpy(
+                host_image_float_.data() + plane_elements * static_cast<std::size_t>(channel),
+                channels[static_cast<std::size_t>(channel)].ptr<float>(),
+                plane_elements * sizeof(float));
+        }
+
+        if (image_binding_.dtype == nvinfer1::DataType::kHALF) {
+            host_image_half_.resize(host_image_float_.size());
+            for (std::size_t index = 0; index < host_image_float_.size(); ++index) {
+                host_image_half_[index] = __float2half(host_image_float_[index]);
+            }
+            image_buffer_.ensure(host_image_half_.size() * sizeof(__half));
+            throw_if_cuda_failed(cudaEventRecord(preprocess_start_event_, stream_), "cudaEventRecord failed for visual upload start");
+            throw_if_cuda_failed(
+                cudaMemcpyAsync(
+                    image_buffer_.data(),
+                    host_image_half_.data(),
+                    host_image_half_.size() * sizeof(__half),
+                    cudaMemcpyHostToDevice,
+                    stream_),
+                "cudaMemcpyAsync for visual image upload failed");
+        } else {
+            image_buffer_.ensure(host_image_float_.size() * sizeof(float));
+            throw_if_cuda_failed(cudaEventRecord(preprocess_start_event_, stream_), "cudaEventRecord failed for visual upload start");
+            throw_if_cuda_failed(
+                cudaMemcpyAsync(
+                    image_buffer_.data(),
+                    host_image_float_.data(),
+                    host_image_float_.size() * sizeof(float),
+                    cudaMemcpyHostToDevice,
+                    stream_),
+                "cudaMemcpyAsync for visual image upload failed");
+        }
+        throw_if_cuda_failed(cudaEventRecord(preprocess_end_event_, stream_), "cudaEventRecord failed for visual upload end");
+        last_preprocess_cpu_ms_ = std::chrono::duration<double, std::milli>(Clock::now() - preprocess_start).count();
+#endif
+    }
+
+    void set_input_dimensions(int target_h, int target_w, int prompt_count)
+    {
+        auto image_dims = image_binding_.dims;
+        if (dims_has_dynamic(image_dims)) {
+            image_dims.d[0] = 1;
+            image_dims.d[2] = target_h;
+            image_dims.d[3] = target_w;
+            if (!context_->setInputShape(image_binding_.name.c_str(), image_dims)) {
+                throw std::runtime_error("Failed to set dynamic visual image tensor shape");
+            }
+        }
+
+        auto visual_dims = visual_binding_.dims;
+        if (dims_has_dynamic(visual_dims)) {
+            visual_dims.d[0] = 1;
+            visual_dims.d[1] = prompt_count;
+            visual_dims.d[2] = target_h / visual_stride_;
+            visual_dims.d[3] = target_w / visual_stride_;
+            if (!context_->setInputShape(visual_binding_.name.c_str(), visual_dims)) {
+                throw std::runtime_error("Failed to set dynamic visual prompt tensor shape");
+            }
+        }
+
+        if (context_->inferShapes(0, nullptr) != 0) {
+            throw std::runtime_error("TensorRT shape inference failed after setting visual input shapes");
+        }
+    }
+
+    void ensure_output_buffers()
+    {
+        for (std::size_t i = 0; i < output_indices_.size(); ++i) {
+            auto const binding_index = output_indices_[i];
+            auto const& binding = bindings_[binding_index];
+            auto const dims = context_->getTensorShape(binding.name.c_str());
+            if (dims.nbDims < 0 || dims_has_dynamic(dims)) {
+                throw std::runtime_error("TensorRT reported unresolved output shape for visual tensor: " + binding.name);
+            }
+            auto const bytes = element_count(dims) * dtype_size(binding.dtype);
+            output_buffers_[i].ensure(bytes);
+            output_shapes_[i] = dims_to_shape(dims);
+        }
+    }
+
+    double execute(void* image_ptr, void* visual_ptr, int target_h, int target_w, int prompt_count)
+    {
+        py::gil_scoped_release release;
+
+        set_input_dimensions(target_h, target_w, prompt_count);
+        ensure_output_buffers();
+
+        if (!context_->setInputTensorAddress(image_binding_.name.c_str(), image_ptr)) {
+            throw std::runtime_error("Failed to bind visual image tensor");
+        }
+        if (!context_->setInputTensorAddress(visual_binding_.name.c_str(), visual_ptr)) {
+            throw std::runtime_error("Failed to bind visual prompt tensor");
+        }
+        for (std::size_t i = 0; i < output_indices_.size(); ++i) {
+            auto const binding_index = output_indices_[i];
+            auto const& binding = bindings_[binding_index];
+            if (!context_->setTensorAddress(binding.name.c_str(), output_buffers_[i].data())) {
+                throw std::runtime_error("Failed to bind visual output tensor: " + binding.name);
+            }
+        }
+
+        throw_if_cuda_failed(cudaEventRecord(inference_start_event_, stream_), "cudaEventRecord failed for visual inference start");
+        if (!context_->enqueueV3(stream_)) {
+            throw std::runtime_error("Visual TensorRT enqueueV3 failed");
+        }
+        throw_if_cuda_failed(cudaEventRecord(inference_end_event_, stream_), "cudaEventRecord failed for visual inference end");
+        throw_if_cuda_failed(cudaStreamSynchronize(stream_), "cudaStreamSynchronize failed after visual inference");
+        return elapsed_event_ms(inference_start_event_, inference_end_event_, "visual TensorRT inference");
+    }
+
+    std::string engine_path_;
+    std::string image_input_name_;
+    std::string visual_input_name_;
+    int visual_stride_ = 8;
+    int device_id_ = 0;
+    cudaStream_t stream_ = nullptr;
+
+    TrtLogger logger_;
+    std::unique_ptr<nvinfer1::IRuntime, TrtDeleter> runtime_;
+    std::unique_ptr<nvinfer1::ICudaEngine, TrtDeleter> engine_;
+    std::unique_ptr<nvinfer1::IExecutionContext, TrtDeleter> context_;
+
+    std::vector<BindingInfo> bindings_;
+    std::vector<int> output_indices_;
+    std::vector<std::string> output_names_;
+
+    int image_input_index_ = -1;
+    int visual_input_index_ = -1;
+    BindingInfo image_binding_{};
+    BindingInfo visual_binding_{};
+
+    bool fp16_ = false;
+    double last_preprocess_cpu_ms_ = 0.0;
+
+    CudaBuffer image_buffer_;
+    CudaBuffer image_upload_buffer_;
+    CudaBuffer visual_buffer_;
+    std::vector<CudaBuffer> output_buffers_;
+    std::vector<std::vector<std::int64_t>> output_shapes_;
+
+#ifndef YOLOE_TRT_ENABLE_CUDA_PREPROCESS
+    std::vector<float> host_image_float_;
+    std::vector<__half> host_image_half_;
+#endif
+    std::vector<__half> visual_half_host_;
+    CudaEventHandle preprocess_start_event_;
+    CudaEventHandle preprocess_end_event_;
+    CudaEventHandle inference_start_event_;
+    CudaEventHandle inference_end_event_;
+};
+
 #ifdef YOLOE_TRT_ENABLE_JETSON_CAMERA
 void ensure_gstreamer_initialized()
 {
@@ -2261,8 +2973,16 @@ PYBIND11_MODULE(_native, m)
         .def(py::init<std::string, std::string, std::string, int>(), py::arg("engine_path"), py::arg("image_input_name"), py::arg("prompt_input_name"), py::arg("device_id") = 0)
         .def_property_readonly("output_names", &NativeMainRuntime::output_names)
         .def_property_readonly("fp16", &NativeMainRuntime::fp16)
+        .def_property_readonly("prompt_fp16", &NativeMainRuntime::prompt_fp16)
         .def("clear_prompt_embeddings", &NativeMainRuntime::clear_prompt_embeddings)
         .def("set_prompt_embeddings", &NativeMainRuntime::set_prompt_embeddings, py::arg("prompt_embeddings"))
+        .def(
+            "set_prompt_embeddings_device",
+            &NativeMainRuntime::set_prompt_embeddings_device,
+            py::arg("prompt_embeddings_ptr"),
+            py::arg("prompt_count"),
+            py::arg("embed_dim"),
+            py::arg("producer_stream") = 0)
         .def("infer_image", &NativeMainRuntime::infer_image, py::arg("image"), py::arg("target_h"), py::arg("target_w"))
         .def(
             "infer_image_postprocessed",
@@ -2303,6 +3023,33 @@ PYBIND11_MODULE(_native, m)
             py::arg("retina_masks"),
             py::arg("producer_stream") = 0)
         .def("warmup", &NativeMainRuntime::warmup, py::arg("target_h"), py::arg("target_w"), py::arg("prompt_count"), py::arg("runs") = 2);
+
+    py::class_<NativeVisualPromptRuntime, std::shared_ptr<NativeVisualPromptRuntime>>(m, "NativeVisualPromptRuntime")
+        .def(
+            py::init<std::string, std::string, std::string, int, int>(),
+            py::arg("engine_path"),
+            py::arg("image_input_name"),
+            py::arg("visual_input_name"),
+            py::arg("visual_stride"),
+            py::arg("device_id") = 0)
+        .def_property_readonly("output_names", &NativeVisualPromptRuntime::output_names)
+        .def_property_readonly("fp16", &NativeVisualPromptRuntime::fp16)
+        .def(
+            "infer_image",
+            &NativeVisualPromptRuntime::infer_image,
+            py::arg("image"),
+            py::arg("target_h"),
+            py::arg("target_w"),
+            py::arg("categories"),
+            py::arg("bboxes") = py::none(),
+            py::arg("masks") = py::none())
+        .def(
+            "warmup",
+            &NativeVisualPromptRuntime::warmup,
+            py::arg("target_h"),
+            py::arg("target_w"),
+            py::arg("prompt_count"),
+            py::arg("runs") = 2);
 
 #ifdef YOLOE_TRT_ENABLE_JETSON_CAMERA
     py::class_<NativeJetsonCameraSource, std::shared_ptr<NativeJetsonCameraSource>>(m, "NativeJetsonCameraSource")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -59,3 +59,4 @@ def test_benchmark_cli_displays_help() -> None:
     assert result.returncode == 0
     assert "Benchmark host-image and CUDA-tensor inference" in result.stdout
     assert "--mode" in result.stdout
+    assert "--visual-prompts" in result.stdout

--- a/tests/test_runtime_integration.py
+++ b/tests/test_runtime_integration.py
@@ -9,6 +9,9 @@ import torch
 from PIL import Image
 from torch.utils.dlpack import from_dlpack
 from yoloe_tensorrt import GStreamerSource, PreparedTensorInput, YOLOEEngine
+from yoloe_tensorrt import engine as engine_module
+from yoloe_tensorrt.preprocess import normalize_imgsz, preprocess_image
+from yoloe_tensorrt.prompts import build_visual_prompt_batch
 from yoloe_tensorrt.source import SourceItem, normalize_source
 
 TEST_CONF = 0.1
@@ -168,6 +171,43 @@ def _python_reference_from_native_tensor_outputs(
     )
 
 
+def _python_visual_prompt_reference(
+    engine: YOLOEEngine,
+    refer_image: object,
+    *,
+    bboxes: np.ndarray | list[list[float]] | None = None,
+    masks: np.ndarray | None = None,
+    classes: list[str] | None = None,
+    imgsz: int | tuple[int, int] | list[int] | None = None,
+) -> tuple[torch.Tensor, list[str]]:
+    assert engine.visual_runtime is not None
+    source_item = normalize_source(refer_image, default_prefix="refer")[0]
+    target_size = normalize_imgsz(imgsz or engine.metadata.default_imgsz)
+    sample = preprocess_image(
+        source_item,
+        imgsz=target_size,
+        device=engine.device,
+        fp16=engine.visual_runtime.fp16,
+        stride=engine.metadata.stride,
+    )
+    prompt_batch = build_visual_prompt_batch(
+        image=sample.original,
+        dst_shape=sample.transformed.shape[:2],
+        visual_stride=engine.metadata.visual_stride,
+        bboxes=bboxes,
+        masks=masks,
+        classes=classes,
+    )
+    outputs = engine.visual_runtime.infer(
+        {
+            engine.metadata.image_input_name: sample.tensor,
+            engine.metadata.visual_input_name: prompt_batch.tensor.to(engine.device),
+        }
+    )
+    prompt_output_name = engine.visual_runtime.output_names[0]
+    return outputs[prompt_output_name].float(), prompt_batch.names
+
+
 @pytest.mark.integration
 @pytest.mark.parametrize(
     ("image_key", "labels"),
@@ -224,6 +264,7 @@ def test_engine_predicts_bus_image_with_visual_prompt(
     test_images: dict[str, Path],
 ) -> None:
     runtime_engine.clear_prompts()
+    assert runtime_engine.native_visual_runtime is not None
     image_path = test_images["bus"]
 
     runtime_engine.set_visual_prompts(
@@ -236,6 +277,252 @@ def test_engine_predicts_bus_image_with_visual_prompt(
     assert len(results) == 1
     _assert_result_contract(results[0], image_path, {0: "bus"})
     assert results[0].boxes.data.shape[0] >= 1
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("prompt_mode", ["bbox", "mask"])
+def test_native_visual_prompt_embeddings_match_python_reference(
+    runtime_engine: YOLOEEngine,
+    engine_artifact_dir: Path,
+    integration_imgsz: int,
+    test_images: dict[str, Path],
+    monkeypatch: pytest.MonkeyPatch,
+    prompt_mode: str,
+) -> None:
+    assert runtime_engine.native_visual_runtime is not None
+    image_path = test_images["bus"]
+    source_item = normalize_source(image_path, default_prefix="refer")[0]
+
+    if prompt_mode == "bbox":
+        prompt_kwargs = {
+            "bboxes": [[20, 230, 810, 1060], [140, 260, 760, 1040], [540, 260, 760, 820]],
+            "classes": ["bus", "bus", "person"],
+        }
+    else:
+        masks = np.zeros((3, source_item.image.shape[0], source_item.image.shape[1]), dtype=np.uint8)
+        masks[0, 230:1060, 20:810] = 1
+        masks[1, 260:1040, 140:760] = 1
+        masks[2, 260:820, 540:760] = 1
+        prompt_kwargs = {
+            "masks": masks,
+            "classes": ["bus", "bus", "person"],
+        }
+
+    runtime_engine.clear_prompts()
+    runtime_engine.set_visual_prompts(image_path, imgsz=integration_imgsz, **prompt_kwargs)
+    native_embeddings = runtime_engine._visual_prompt_embeddings
+    assert native_embeddings is not None
+    native_names = list(runtime_engine._visual_names)
+
+    monkeypatch.setattr(engine_module, "build_native_visual_runtime", lambda *args, **kwargs: None)
+    python_visual_engine = YOLOEEngine.from_engine(engine_artifact_dir, device=str(runtime_engine.device))
+    try:
+        assert python_visual_engine.native_visual_runtime is None
+        reference_embeddings, reference_names = _python_visual_prompt_reference(
+            python_visual_engine,
+            image_path,
+            imgsz=integration_imgsz,
+            **prompt_kwargs,
+        )
+    finally:
+        python_visual_engine.clear_prompts()
+
+    assert native_names == reference_names
+    torch.testing.assert_close(
+        native_embeddings.detach().cpu(),
+        reference_embeddings.detach().cpu(),
+        atol=2e-3,
+        rtol=1e-3,
+    )
+
+
+@pytest.mark.integration
+def test_native_visual_prompt_accepts_unit_range_float_reference_image(
+    runtime_engine: YOLOEEngine,
+    engine_artifact_dir: Path,
+    integration_imgsz: int,
+    test_images: dict[str, Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    assert runtime_engine.native_visual_runtime is not None
+    image_path = test_images["bus"]
+    source_item = normalize_source(image_path, default_prefix="refer")[0]
+    float_image = source_item.image.astype(np.float32) / 255.0
+    prompt_kwargs = {
+        "bboxes": [[20, 230, 810, 1060]],
+        "classes": ["bus"],
+    }
+
+    runtime_engine.clear_prompts()
+    runtime_engine.set_visual_prompts(float_image, imgsz=integration_imgsz, **prompt_kwargs)
+    native_embeddings = runtime_engine._visual_prompt_embeddings
+    assert native_embeddings is not None
+
+    monkeypatch.setattr(engine_module, "build_native_visual_runtime", lambda *args, **kwargs: None)
+    python_visual_engine = YOLOEEngine.from_engine(engine_artifact_dir, device=str(runtime_engine.device))
+    try:
+        reference_embeddings, reference_names = _python_visual_prompt_reference(
+            python_visual_engine,
+            float_image,
+            imgsz=integration_imgsz,
+            **prompt_kwargs,
+        )
+    finally:
+        python_visual_engine.clear_prompts()
+
+    assert runtime_engine._visual_names == reference_names
+    torch.testing.assert_close(
+        native_embeddings.detach().cpu(),
+        reference_embeddings.detach().cpu(),
+        atol=2e-3,
+        rtol=1e-3,
+    )
+
+
+@pytest.mark.integration
+def test_visual_prompt_bboxes_take_precedence_over_unused_masks(
+    runtime_engine: YOLOEEngine,
+    integration_imgsz: int,
+    test_images: dict[str, Path],
+) -> None:
+    runtime_engine.clear_prompts()
+    assert runtime_engine.native_visual_runtime is not None
+
+    runtime_engine.set_visual_prompts(
+        test_images["bus"],
+        bboxes=[[20, 230, 810, 1060]],
+        masks=object(),
+        classes=["bus"],
+        imgsz=integration_imgsz,
+    )
+
+    assert runtime_engine._visual_prompt_embeddings is not None
+    assert runtime_engine._visual_names == ["bus"]
+
+
+@pytest.mark.integration
+def test_visual_prompt_embeddings_are_reused_across_repeated_inference_calls(
+    runtime_engine: YOLOEEngine,
+    integration_imgsz: int,
+    test_images: dict[str, Path],
+) -> None:
+    runtime_engine.clear_prompts()
+    assert runtime_engine.native_visual_runtime is not None
+
+    image_path = test_images["bus"]
+    runtime_engine.set_visual_prompts(
+        image_path,
+        bboxes=[[20, 230, 810, 1060]],
+        classes=["bus"],
+        imgsz=integration_imgsz,
+    )
+    embeddings = runtime_engine._visual_prompt_embeddings
+    assert embeddings is not None
+    original_ptr = int(embeddings.data_ptr())
+    original_generation = int(runtime_engine._prompt_generation)
+
+    _ = runtime_engine.predict(image_path, conf=TEST_CONF)
+    _ = list(runtime_engine.track([image_path, image_path], stream=True, conf=TEST_CONF, tracker="bytetrack"))
+
+    assert runtime_engine._visual_prompt_embeddings is not None
+    assert int(runtime_engine._visual_prompt_embeddings.data_ptr()) == original_ptr
+    assert int(runtime_engine._prompt_generation) == original_generation
+
+
+@pytest.mark.integration
+def test_native_inference_uses_cached_prompt_names_without_reconcatenating_embeddings(
+    runtime_engine: YOLOEEngine,
+    integration_imgsz: int,
+    test_images: dict[str, Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime_engine.clear_prompts()
+    runtime_engine.set_classes(["bus"])
+    assert runtime_engine.native_main_runtime is not None
+
+    def _fail_concat(*args, **kwargs):
+        raise AssertionError("native inference should not concatenate prompt embeddings after prompts are synced")
+
+    monkeypatch.setattr(engine_module, "concat_prompt_embeddings", _fail_concat)
+
+    image_path = test_images["bus"]
+    result = runtime_engine.predict(image_path, conf=TEST_CONF, imgsz=integration_imgsz)[0]
+    prepared = runtime_engine.prepare_cuda_input(image_path, imgsz=integration_imgsz)
+    prepared_result = runtime_engine.predict(prepared, conf=TEST_CONF)[0]
+
+    _assert_result_contract(result, image_path, {0: "bus"})
+    _assert_result_contract(prepared_result, image_path, {0: "bus"})
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("native_builder_failure", ["returns_none", "raises"])
+def test_visual_prompt_python_fallback_remains_available(
+    engine_artifact_dir: Path,
+    integration_imgsz: int,
+    test_images: dict[str, Path],
+    monkeypatch: pytest.MonkeyPatch,
+    native_builder_failure: str,
+) -> None:
+    if native_builder_failure == "raises":
+
+        def _raise_native_visual_error(*args, **kwargs):
+            raise RuntimeError("synthetic native visual runtime failure")
+
+        monkeypatch.setattr(engine_module, "build_native_visual_runtime", _raise_native_visual_error)
+    else:
+        monkeypatch.setattr(engine_module, "build_native_visual_runtime", lambda *args, **kwargs: None)
+    engine = YOLOEEngine.from_engine(engine_artifact_dir)
+    try:
+        assert engine.native_visual_runtime is None
+        assert engine.visual_runtime is not None
+        image_path = test_images["bus"]
+
+        engine.clear_prompts()
+        engine.set_visual_prompts(
+            image_path,
+            bboxes=[[20, 230, 810, 1060]],
+            classes=["bus"],
+            imgsz=integration_imgsz,
+        )
+        results = engine.predict(image_path, conf=TEST_CONF)
+
+        assert len(results) == 1
+        _assert_result_contract(results[0], image_path, {0: "bus"})
+        assert results[0].boxes.data.shape[0] >= 1
+    finally:
+        engine.clear_prompts()
+
+
+@pytest.mark.integration
+def test_visual_prompt_python_fallback_accepts_target_shape_masks(
+    engine_artifact_dir: Path,
+    integration_imgsz: int,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(engine_module, "build_native_visual_runtime", lambda *args, **kwargs: None)
+    engine = YOLOEEngine.from_engine(engine_artifact_dir)
+    try:
+        assert engine.native_visual_runtime is None
+        assert engine.visual_runtime is not None
+
+        image = np.zeros((integration_imgsz, integration_imgsz, 3), dtype=np.uint8)
+        masks = np.zeros((1, integration_imgsz, integration_imgsz), dtype=np.uint8)
+        prompt_start = integration_imgsz // 4
+        prompt_end = integration_imgsz * 3 // 4
+        masks[0, prompt_start:prompt_end, prompt_start:prompt_end] = 1
+
+        engine.clear_prompts()
+        engine.set_visual_prompts(
+            image,
+            masks=masks,
+            classes=["object"],
+            imgsz=integration_imgsz,
+        )
+
+        assert engine._visual_prompt_embeddings is not None
+        assert engine._visual_names == ["object"]
+    finally:
+        engine.clear_prompts()
 
 
 @pytest.mark.integration

--- a/yoloe_tensorrt/benchmark_cli.py
+++ b/yoloe_tensorrt/benchmark_cli.py
@@ -1,16 +1,23 @@
 from __future__ import annotations
 
 import argparse
+import logging
 import statistics
 import time
+from contextlib import contextmanager
 from pathlib import Path
+
+import numpy as np
 
 from .logging_utils import configure_logging
 
 
 def build_arg_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
-        description="Benchmark host-image and CUDA-tensor inference paths for a YOLOE TensorRT artifact bundle."
+        description=(
+            "Benchmark host-image and CUDA-tensor inference paths for a YOLOE TensorRT artifact bundle, "
+            "and optionally benchmark visual-prompt updates."
+        )
     )
     parser.add_argument("artifact_dir", help="Artifact bundle directory to benchmark.")
     parser.add_argument("image", help="Image path to use for repeated benchmark runs.")
@@ -32,6 +39,18 @@ def build_arg_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--conf", type=float, default=0.25, help="Detection confidence threshold.")
     parser.add_argument("--device", default="cuda:0", help="Torch/TensorRT device. Defaults to cuda:0.")
+    parser.add_argument(
+        "--visual-prompts",
+        choices=("none", "bbox", "mask", "both"),
+        default="none",
+        help="Also benchmark set_visual_prompts() using bbox prompts, mask prompts, or both.",
+    )
+    parser.add_argument(
+        "--visual-runtime",
+        choices=("native", "python", "both"),
+        default="both",
+        help="Which visual-prompt runtime to benchmark when --visual-prompts is enabled.",
+    )
     parser.add_argument("--log-level", default="INFO", help="Logging level for the benchmark command.")
     return parser
 
@@ -56,19 +75,72 @@ def _summarize_result_speeds(name: str, speeds: list[dict[str, float]]) -> None:
     )
 
 
+def _build_engine(artifact_dir: Path, device: str, *, disable_native_visual: bool = False):
+    from . import engine as engine_module
+    from .engine import YOLOEEngine
+
+    if not disable_native_visual:
+        return YOLOEEngine.from_engine(artifact_dir, device=device)
+
+    original_builder = engine_module.build_native_visual_runtime
+    engine_module.build_native_visual_runtime = lambda *args, **kwargs: None
+    try:
+        return YOLOEEngine.from_engine(artifact_dir, device=device)
+    finally:
+        engine_module.build_native_visual_runtime = original_builder
+
+
+def _build_visual_prompt_inputs(image: np.ndarray, label: str) -> dict[str, dict[str, object]]:
+    image_h, image_w = image.shape[:2]
+    x1 = int(round(image_w * 0.2))
+    y1 = int(round(image_h * 0.2))
+    x2 = int(round(image_w * 0.8))
+    y2 = int(round(image_h * 0.8))
+    mask = np.zeros((1, image_h, image_w), dtype=np.uint8)
+    mask[0, y1:y2, x1:x2] = 1
+    return {
+        "bbox": {
+            "bboxes": [[float(x1), float(y1), float(x2), float(y2)]],
+            "classes": [label],
+        },
+        "mask": {
+            "masks": mask,
+            "classes": [label],
+        },
+    }
+
+
+@contextmanager
+def _suppress_info_logs_for_timing():
+    previous_disable_level = logging.root.manager.disable
+    logging.disable(logging.INFO)
+    try:
+        yield
+    finally:
+        logging.disable(previous_disable_level)
+
+
+def _synchronize_engine_device(engine: object) -> None:
+    import torch
+
+    device = torch.device(getattr(engine, "device", "cuda:0"))
+    if device.type == "cuda":
+        torch.cuda.synchronize(device)
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = build_arg_parser()
     args = parser.parse_args(argv)
     configure_logging(level=args.log_level, include_timestamps=True)
 
-    from .engine import YOLOEEngine
     from .preprocess import normalize_imgsz
     from .source import normalize_source
 
     labels = list(args.labels or ["bus"])
     target_size = normalize_imgsz(int(args.imgsz))
 
-    engine = YOLOEEngine.from_engine(Path(args.artifact_dir), device=args.device)
+    artifact_dir = Path(args.artifact_dir)
+    engine = _build_engine(artifact_dir, args.device)
     engine.clear_prompts()
     engine.set_classes(labels)
 
@@ -102,6 +174,42 @@ def main(argv: list[str] | None = None) -> int:
         fps = 1000.0 / statistics.fmean(latencies_ms)
         print(f"{name}: runs={int(args.runs)} {_format_ms(latencies_ms)} fps={fps:.2f}")
         _summarize_result_speeds(name, speeds)
+
+    if args.visual_prompts != "none":
+        visual_prompt_inputs = _build_visual_prompt_inputs(item.image, labels[0])
+        visual_modes = ["bbox", "mask"] if args.visual_prompts == "both" else [str(args.visual_prompts)]
+        visual_runtime_labels: list[tuple[str, object]] = []
+        if args.visual_runtime in {"native", "both"}:
+            if engine.native_visual_runtime is not None:
+                visual_runtime_labels.append(("native", engine))
+            else:
+                print("visual-native: skipped (native visual runtime unavailable)")
+        if args.visual_runtime in {"python", "both"}:
+            python_visual_engine = _build_engine(artifact_dir, args.device, disable_native_visual=True)
+            if python_visual_engine.visual_runtime is not None:
+                visual_runtime_labels.append(("python", python_visual_engine))
+            else:
+                print("visual-python: skipped (Python visual runtime unavailable)")
+
+        for runtime_name, visual_engine in visual_runtime_labels:
+            for visual_mode in visual_modes:
+                prompt_kwargs = visual_prompt_inputs[visual_mode]
+                for _ in range(int(args.warmup)):
+                    with _suppress_info_logs_for_timing():
+                        visual_engine.clear_prompts()
+                        visual_engine.set_visual_prompts(item.image, imgsz=target_size, **prompt_kwargs)
+                        _synchronize_engine_device(visual_engine)
+
+                latencies_ms: list[float] = []
+                for _ in range(int(args.runs)):
+                    with _suppress_info_logs_for_timing():
+                        visual_engine.clear_prompts()
+                        start = time.perf_counter()
+                        visual_engine.set_visual_prompts(item.image, imgsz=target_size, **prompt_kwargs)
+                        _synchronize_engine_device(visual_engine)
+                    latencies_ms.append((time.perf_counter() - start) * 1000.0)
+
+                print(f"visual-{runtime_name}-{visual_mode}: runs={int(args.runs)} {_format_ms(latencies_ms)}")
 
     return 0
 

--- a/yoloe_tensorrt/engine.py
+++ b/yoloe_tensorrt/engine.py
@@ -21,7 +21,10 @@ from .inputs import (
     validate_prepared_tensor,
 )
 from .logging_utils import get_logger
-from .native_backend import build_native_main_runtime
+from .native_backend import (
+    build_native_main_runtime,
+    build_native_visual_runtime,
+)
 from .preprocess import normalize_imgsz, preprocess_image
 from .prompts import (
     TextPromptEncoder,
@@ -29,7 +32,10 @@ from .prompts import (
     compile_text_embeddings,
     concat_prompt_embeddings,
     load_prompt_projector,
+    normalize_visual_prompt_boxes,
+    normalize_visual_prompt_masks,
     resolve_text_asset_path,
+    resolve_visual_prompt_categories,
 )
 from .source import PreparedFrameMetadata, SourceItem, normalize_source
 from .tracking import DEFAULT_TRACKER, YOLOETrackerSession
@@ -49,6 +55,7 @@ class YOLOEEngine:
         device: str | torch.device = "cuda:0",
         text_encoder_path: str | Path | None = None,
         native_main_runtime: object | None = None,
+        native_visual_runtime: object | None = None,
     ) -> None:
         self.artifact_dir = Path(artifact_dir)
         self.metadata = metadata
@@ -56,6 +63,7 @@ class YOLOEEngine:
         self.main_runtime = main_runtime
         self.native_main_runtime = native_main_runtime
         self.visual_runtime = visual_runtime
+        self.native_visual_runtime = native_visual_runtime
         self.prompt_projector = prompt_projector
         self._text_encoder_path = Path(text_encoder_path) if text_encoder_path else None
         self._text_encoder: TextPromptEncoder | None = None
@@ -138,18 +146,33 @@ class YOLOEEngine:
             prompt_input_name=metadata.prompt_input_name,
             device=device,
         )
+        native_visual_runtime = None
+        if visual_engine and visual_engine.is_file():
+            try:
+                native_visual_runtime = build_native_visual_runtime(
+                    visual_engine,
+                    image_input_name=metadata.image_input_name,
+                    visual_input_name=metadata.visual_input_name,
+                    visual_stride=metadata.visual_stride,
+                    device=device,
+                )
+            except Exception as exc:
+                LOGGER.warning("Native visual runtime unavailable; falling back to Python TensorRT path: %s", exc)
 
         return cls(
             artifact_dir=artifact_root,
             metadata=metadata,
             main_runtime=None if native_main_runtime is not None else TensorRTRuntime(main_engine, device=device),
-            visual_runtime=TensorRTRuntime(visual_engine, device=device)
-            if visual_engine and visual_engine.is_file()
-            else None,
+            visual_runtime=(
+                None
+                if native_visual_runtime is not None or not (visual_engine and visual_engine.is_file())
+                else TensorRTRuntime(visual_engine, device=device)
+            ),
             prompt_projector=load_prompt_projector(projector_path, device=torch.device(device)),
             device=device,
             text_encoder_path=preferred_text_path,
             native_main_runtime=native_main_runtime,
+            native_visual_runtime=native_visual_runtime,
         )
 
     def _get_text_encoder(self) -> TextPromptEncoder:
@@ -169,6 +192,12 @@ class YOLOEEngine:
             self._visual_prompt_embeddings,
             self._visual_names,
         )
+
+    def _active_prompt_names(self) -> list[str]:
+        names = [*self._text_names, *self._visual_names]
+        if not names:
+            raise RuntimeError("No prompt embeddings are active. Call set_classes() or set_visual_prompts() first.")
+        return names
 
     @property
     def _main_output_names(self) -> list[str]:
@@ -194,10 +223,48 @@ class YOLOEEngine:
         except RuntimeError:
             self.native_main_runtime.clear_prompt_embeddings()
             return
-        self.native_main_runtime.set_prompt_embeddings(embeddings.detach().float().cpu().contiguous().numpy())
+        tensor = embeddings.detach().contiguous()
+        if hasattr(self.native_main_runtime, "set_prompt_embeddings_device"):
+            target_dtype = (
+                torch.float16 if bool(getattr(self.native_main_runtime, "prompt_fp16", False)) else torch.float32
+            )
+            if tensor.dtype != target_dtype:
+                tensor = tensor.to(device=self.device, dtype=target_dtype)
+            producer_stream = int(torch.cuda.current_stream(self.device).cuda_stream)
+            self.native_main_runtime.set_prompt_embeddings_device(
+                int(tensor.data_ptr()),
+                int(tensor.shape[1]),
+                int(tensor.shape[2]),
+                producer_stream,
+            )
+            return
+        self.native_main_runtime.set_prompt_embeddings(tensor.float().cpu().contiguous().numpy())
 
     def _bump_prompt_generation(self) -> None:
         self._prompt_generation += 1
+
+    def _describe_source(self, source: object) -> str:
+        if isinstance(source, SourceItem):
+            return str(source.path)
+        if isinstance(source, np.ndarray):
+            return f"ndarray(shape={tuple(int(v) for v in source.shape)}, dtype={source.dtype})"
+        if isinstance(source, torch.Tensor):
+            return f"tensor(shape={tuple(int(v) for v in source.shape)}, dtype={source.dtype}, device={source.device})"
+        return str(source)
+
+    def _native_visual_image(self, image: np.ndarray) -> np.ndarray:
+        if image.dtype == np.uint8:
+            return np.ascontiguousarray(image)
+        if np.issubdtype(image.dtype, np.floating):
+            min_value = float(image.min())
+            max_value = float(image.max())
+            if 0.0 <= min_value and max_value <= 1.0:
+                return np.ascontiguousarray(np.rint(image * 255.0).clip(0.0, 255.0).astype(np.uint8))
+            if 0.0 <= min_value and max_value <= 255.0:
+                return np.ascontiguousarray(np.rint(image).clip(0.0, 255.0).astype(np.uint8))
+        raise ValueError(
+            "Native visual prompts require uint8 reference images or non-negative float images in 0..1 or 0..255 range"
+        )
 
     def clear_prompts(self) -> None:
         self._text_prompt_embeddings = None
@@ -256,35 +323,63 @@ class YOLOEEngine:
         classes: list[str] | None = None,
         imgsz: int | tuple[int, int] | list[int] | None = None,
     ) -> None:
-        if self.visual_runtime is None:
+        if self.native_visual_runtime is None and self.visual_runtime is None:
             raise RuntimeError("This artifact bundle does not include a visual-prompt engine")
-        LOGGER.info("Setting visual prompts from '%s'", refer_image)
+        if bboxes is None and masks is None:
+            raise ValueError("Either bboxes or masks must be provided")
+        LOGGER.info("Setting visual prompts from '%s'", self._describe_source(refer_image))
         source_item = normalize_source(refer_image, default_prefix="refer")[0]
         target_size = normalize_imgsz(imgsz or self.metadata.default_imgsz)
-        sample = preprocess_image(
-            source_item,
-            imgsz=target_size,
-            device=self.device,
-            fp16=self.visual_runtime.fp16,
-            stride=self.metadata.stride,
-        )
-        prompt_batch = build_visual_prompt_batch(
-            image=sample.original,
-            dst_shape=sample.transformed.shape[:2],
-            visual_stride=self.metadata.visual_stride,
-            bboxes=bboxes,
-            masks=masks,
-            classes=classes,
-        )
-        outputs = self.visual_runtime.infer(
-            {
-                self.metadata.image_input_name: sample.tensor,
-                self.metadata.visual_input_name: prompt_batch.tensor.to(self.device),
-            }
-        )
-        prompt_output_name = self.visual_runtime.output_names[0]
-        self._visual_prompt_embeddings = outputs[prompt_output_name].float()
-        self._visual_names = prompt_batch.names
+        boxes = normalize_visual_prompt_boxes(bboxes) if bboxes is not None else None
+        masks_array = None
+        if boxes is not None:
+            prompt_count = int(boxes.shape[0])
+        elif masks is not None:
+            masks_array = normalize_visual_prompt_masks(masks)
+            prompt_count = int(masks_array.shape[0])
+        else:
+            prompt_count = 0
+        categories, names = resolve_visual_prompt_categories(prompt_count, classes)
+
+        if self.native_visual_runtime is not None:
+            native_outputs = self.native_visual_runtime.infer_image(
+                self._native_visual_image(source_item.image),
+                int(target_size[0]),
+                int(target_size[1]),
+                categories,
+                boxes,
+                masks_array,
+            )
+            prompt_output_name = self.native_visual_runtime.output_names[0]
+            prompt_embeddings = from_dlpack(native_outputs[prompt_output_name]).float().contiguous().clone()
+        else:
+            assert self.visual_runtime is not None
+            sample = preprocess_image(
+                source_item,
+                imgsz=target_size,
+                device=self.device,
+                fp16=self.visual_runtime.fp16,
+                stride=self.metadata.stride,
+            )
+            prompt_batch = build_visual_prompt_batch(
+                image=sample.original,
+                dst_shape=sample.transformed.shape[:2],
+                visual_stride=self.metadata.visual_stride,
+                bboxes=boxes,
+                masks=masks_array,
+                classes=classes,
+            )
+            outputs = self.visual_runtime.infer(
+                {
+                    self.metadata.image_input_name: sample.tensor,
+                    self.metadata.visual_input_name: prompt_batch.tensor.to(self.device),
+                }
+            )
+            prompt_output_name = self.visual_runtime.output_names[0]
+            prompt_embeddings = outputs[prompt_output_name].float()
+            names = prompt_batch.names
+        self._visual_prompt_embeddings = prompt_embeddings
+        self._visual_names = names
         self._bump_prompt_generation()
         self._sync_native_prompt_embeddings()
         LOGGER.info(
@@ -309,18 +404,21 @@ class YOLOEEngine:
                 self.metadata.prompt_input_name: (1, prompt_count, self.metadata.embed_dim),
             }
             self.main_runtime.warmup(shapes=shapes)
-        if self.visual_runtime is not None and self.metadata.visual_profile is not None:
-            self.visual_runtime.warmup(
-                shapes={
-                    self.metadata.image_input_name: (1, 3, target[0], target[1]),
-                    self.metadata.visual_input_name: (
-                        1,
-                        self.metadata.visual_profile.optimum[1],
-                        target[0] // self.metadata.visual_stride,
-                        target[1] // self.metadata.visual_stride,
-                    ),
-                }
-            )
+        if self.metadata.visual_profile is not None:
+            if self.native_visual_runtime is not None:
+                self.native_visual_runtime.warmup(target[0], target[1], self.metadata.visual_profile.optimum[1], 2)
+            elif self.visual_runtime is not None:
+                self.visual_runtime.warmup(
+                    shapes={
+                        self.metadata.image_input_name: (1, 3, target[0], target[1]),
+                        self.metadata.visual_input_name: (
+                            1,
+                            self.metadata.visual_profile.optimum[1],
+                            target[0] // self.metadata.visual_stride,
+                            target[1] // self.metadata.visual_stride,
+                        ),
+                    }
+                )
         LOGGER.info("YOLOEEngine warmup complete")
 
     @property
@@ -386,7 +484,11 @@ class YOLOEEngine:
         max_det: int,
         retina_masks: bool,
     ) -> Results:
-        prompt_embeddings, names = self._active_prompt_embeddings()
+        if self.native_main_runtime is not None:
+            prompt_embeddings = None
+            names = self._active_prompt_names()
+        else:
+            prompt_embeddings, names = self._active_prompt_embeddings()
         LOGGER.debug(
             "Running inference on '%s' with %d active prompt class(es) at imgsz=%s",
             item.path,
@@ -585,7 +687,11 @@ class YOLOEEngine:
         max_det: int,
         retina_masks: bool,
     ) -> Results:
-        prompt_embeddings, names = self._active_prompt_embeddings()
+        if self.native_main_runtime is not None:
+            prompt_embeddings = None
+            names = self._active_prompt_names()
+        else:
+            prompt_embeddings, names = self._active_prompt_embeddings()
 
         image_tensor = item.tensor
         validate_prepared_tensor(image_tensor)

--- a/yoloe_tensorrt/native_backend.py
+++ b/yoloe_tensorrt/native_backend.py
@@ -11,12 +11,14 @@ try:
     from . import _native as _native_module
 
     NativeMainRuntime = _native_module.NativeMainRuntime  # type: ignore[attr-defined]
+    NativeVisualPromptRuntime = getattr(_native_module, "NativeVisualPromptRuntime", None)
     NativeJetsonCameraSource = getattr(_native_module, "NativeJetsonCameraSource", None)
 
     NATIVE_AVAILABLE = os.environ.get("YOLOE_TRT_DISABLE_NATIVE", "").lower() not in {"1", "true", "yes"}
     NATIVE_IMPORT_ERROR: Exception | None = None
 except Exception as exc:  # pragma: no cover - import surface depends on local build/runtime libs
     NativeMainRuntime = None  # type: ignore[assignment]
+    NativeVisualPromptRuntime = None  # type: ignore[assignment]
     NativeJetsonCameraSource = None  # type: ignore[assignment]
     NATIVE_AVAILABLE = False
     NATIVE_IMPORT_ERROR = exc
@@ -49,6 +51,43 @@ def build_native_main_runtime(
             device_id = 0
 
     return NativeMainRuntime(str(engine_path), image_input_name, prompt_input_name, device_id)
+
+
+def build_native_visual_runtime(
+    engine_path: str | Path,
+    image_input_name: str,
+    visual_input_name: str,
+    visual_stride: int,
+    device: str | int = "cuda:0",
+):
+    if not NATIVE_AVAILABLE or NativeVisualPromptRuntime is None:
+        if NATIVE_IMPORT_ERROR is not None:
+            LOGGER.info("Native visual backend unavailable: %s", NATIVE_IMPORT_ERROR)
+        return None
+
+    if isinstance(device, int):
+        device_id = device
+    else:
+        device_str = str(device)
+        if not device_str.startswith("cuda"):
+            LOGGER.info("Native visual backend disabled for non-CUDA device '%s'", device_str)
+            return None
+        if ":" in device_str:
+            device_id = int(device_str.split(":", 1)[1])
+        else:
+            device_id = 0
+
+    try:
+        return NativeVisualPromptRuntime(
+            str(engine_path),
+            image_input_name,
+            visual_input_name,
+            int(visual_stride),
+            device_id,
+        )
+    except Exception as exc:  # pragma: no cover - depends on local TensorRT/CUDA runtime state
+        LOGGER.warning("Native visual backend unavailable: %s", exc)
+        return None
 
 
 def build_native_jetson_camera_source(

--- a/yoloe_tensorrt/prompts.py
+++ b/yoloe_tensorrt/prompts.py
@@ -176,9 +176,33 @@ def _preserve_unique_names(names: list[str]) -> tuple[np.ndarray, list[str]]:
     return np.asarray(ids, dtype=np.int32), resolved
 
 
-def _resize_masks(
+def resolve_visual_prompt_categories(
+    prompt_count: int,
+    classes: list[str] | None = None,
+) -> tuple[np.ndarray, list[str]]:
+    if prompt_count <= 0:
+        raise ValueError("visual prompts must contain at least one prompt")
+    if classes is None:
+        names = [f"object{i}" for i in range(prompt_count)]
+        return np.arange(prompt_count, dtype=np.int32), names
+    if len(classes) != prompt_count:
+        raise ValueError("classes must match the number of visual prompts")
+    return _preserve_unique_names(classes)
+
+
+def normalize_visual_prompt_boxes(bboxes: np.ndarray | list[list[float]]) -> np.ndarray:
+    boxes = np.asarray(bboxes, dtype=np.float32)
+    if boxes.ndim == 1:
+        boxes = boxes[None, :]
+    if boxes.ndim != 2 or boxes.shape[1] != 4:
+        raise ValueError(f"Expected bboxes with shape (N, 4), got {boxes.shape}")
+    if boxes.shape[0] == 0:
+        raise ValueError("bboxes must not be empty")
+    return boxes
+
+
+def normalize_visual_prompt_masks(
     masks: np.ndarray | list[np.ndarray] | torch.Tensor,
-    dst_shape: tuple[int, int],
 ) -> np.ndarray:
     if isinstance(masks, torch.Tensor):
         masks = masks.detach().cpu().numpy()
@@ -187,6 +211,16 @@ def _resize_masks(
         masks_array = masks_array[None, ...]
     if masks_array.ndim != 3:
         raise ValueError(f"Expected masks with shape (N, H, W), got {masks_array.shape}")
+    if masks_array.shape[0] == 0:
+        raise ValueError("masks must not be empty")
+    return masks_array
+
+
+def _resize_masks(
+    masks: np.ndarray | list[np.ndarray] | torch.Tensor,
+    dst_shape: tuple[int, int],
+) -> np.ndarray:
+    masks_array = normalize_visual_prompt_masks(masks)
     letterbox = LetterBox(
         new_shape=dst_shape,
         auto=False,
@@ -196,7 +230,10 @@ def _resize_masks(
     )
     resized = []
     for mask in masks_array:
-        output = letterbox(image=np.asarray(mask, dtype=np.uint8))
+        mask_array = np.asarray(mask, dtype=np.uint8)
+        if mask_array.ndim == 2:
+            mask_array = mask_array[..., None]
+        output = letterbox(image=mask_array)
         if output.ndim == 3 and output.shape[-1] == 1:
             output = output[..., 0]
         resized.append(output)
@@ -220,19 +257,9 @@ def build_visual_prompt_batch(
     )
 
     if bboxes is not None:
-        boxes = np.asarray(bboxes, dtype=np.float32)
-        if boxes.ndim == 1:
-            boxes = boxes[None, :]
-        if boxes.ndim != 2 or boxes.shape[1] != 4:
-            raise ValueError(f"Expected bboxes with shape (N, 4), got {boxes.shape}")
+        boxes = normalize_visual_prompt_boxes(bboxes)
         prompt_count = boxes.shape[0]
-        if classes is None:
-            names = [f"object{i}" for i in range(prompt_count)]
-            category = np.arange(prompt_count, dtype=np.int32)
-        else:
-            if len(classes) != prompt_count:
-                raise ValueError("classes must match the number of bboxes")
-            category, names = _preserve_unique_names(classes)
+        category, names = resolve_visual_prompt_categories(prompt_count, classes)
         src_shape = image.shape[:2]
         gain = min(dst_shape[0] / src_shape[0], dst_shape[1] / src_shape[1])
         boxes = boxes.copy()
@@ -247,13 +274,7 @@ def build_visual_prompt_batch(
     else:
         resized_masks = _resize_masks(masks, dst_shape)
         prompt_count = resized_masks.shape[0]
-        if classes is None:
-            names = [f"object{i}" for i in range(prompt_count)]
-            category = np.arange(prompt_count, dtype=np.int32)
-        else:
-            if len(classes) != prompt_count:
-                raise ValueError("classes must match the number of masks")
-            category, names = _preserve_unique_names(classes)
+        category, names = resolve_visual_prompt_categories(prompt_count, classes)
         visuals = LoadVisualPrompt(scale_factor=1 / visual_stride).get_visuals(
             category,
             dst_shape,


### PR DESCRIPTION
  - Added a native NativeVisualPromptRuntime for visual prompt TensorRT execution.
  - Moved visual prompt batching for bbox and mask prompts into the native path.
  - Added device-side prompt embedding sync into the native main runtime to avoid GPU-to-CPU-to-GPU round trips.
  - Fixed native visual handling for unit-range float reference images.
  - Added safe cleanup for native visual runtime construction failures.
  - Fixed Python fallback mask prompt handling for target-shape masks.