### PR TITLE
perf: reduced steady-state inference allocations

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,7 +2,15 @@ from __future__ import annotations
 
 import subprocess
 import sys
+import weakref
 from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+from yoloe_tensorrt import benchmark_cli
+from yoloe_tensorrt.benchmark_cli import _benchmark_runner, _format_ms
+from yoloe_tensorrt.source import SourceItem
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
@@ -60,3 +68,113 @@ def test_benchmark_cli_displays_help() -> None:
     assert "Benchmark host-image and CUDA-tensor inference" in result.stdout
     assert "--mode" in result.stdout
     assert "--visual-prompts" in result.stdout
+    assert "--profile-allocations" in result.stdout
+    assert "--track" in result.stdout
+
+
+def test_benchmark_runner_profiles_allocations(capsys) -> None:
+    def _runner():
+        return SimpleNamespace(speed={"preprocess": 1.0, "inference": 2.0, "postprocess": 3.0})
+
+    _benchmark_runner(
+        "dummy",
+        _runner,
+        runs=1,
+        warmup=0,
+        profile_allocations=True,
+        allocation_top=1,
+    )
+
+    output = capsys.readouterr().out
+    assert "dummy: runs=1" in output
+    assert "dummy Python retained allocations:" in output
+
+
+def test_benchmark_runner_clears_final_result_before_allocation_snapshot(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _Snapshot:
+        def compare_to(self, _before, _group_by):
+            return []
+
+    class _Result:
+        __slots__ = ("speed", "__weakref__")
+
+        def __init__(self) -> None:
+            self.speed = {"preprocess": 1.0, "inference": 2.0, "postprocess": 3.0}
+
+    result_refs: list[weakref.ReferenceType[_Result]] = []
+    snapshot_result_released: list[bool] = []
+
+    def _runner():
+        result = _Result()
+        result_refs.append(weakref.ref(result))
+        return result
+
+    def _take_snapshot():
+        snapshot_result_released.append(not result_refs or result_refs[-1]() is None)
+        return _Snapshot()
+
+    monkeypatch.setattr(benchmark_cli.tracemalloc, "start", lambda: None)
+    monkeypatch.setattr(benchmark_cli.tracemalloc, "get_traced_memory", lambda: (0, 0))
+    monkeypatch.setattr(benchmark_cli.tracemalloc, "take_snapshot", _take_snapshot)
+    monkeypatch.setattr(benchmark_cli.tracemalloc, "stop", lambda: None)
+
+    _benchmark_runner(
+        "dummy",
+        _runner,
+        runs=1,
+        warmup=0,
+        profile_allocations=True,
+        allocation_top=1,
+    )
+
+    assert snapshot_result_released == [True, True]
+
+
+def test_benchmark_latency_summary_uses_nearest_rank_tail_percentiles() -> None:
+    summary = _format_ms([1.0, 2.0, 3.0, 4.0, 100.0])
+
+    assert "p95=100.00ms" in summary
+    assert "p99=100.00ms" in summary
+
+
+def test_benchmark_host_only_does_not_prepare_cuda_input(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    class _Engine:
+        native_visual_runtime = None
+
+        def clear_prompts(self) -> None:
+            pass
+
+        def set_classes(self, _labels: list[str]) -> None:
+            pass
+
+        def prepare_cuda_input(self, *_args, **_kwargs):
+            raise AssertionError("host-only benchmark should not prepare CUDA input")
+
+        def predict_item(self, *_args, **_kwargs):
+            return SimpleNamespace(speed={"preprocess": 1.0, "inference": 2.0, "postprocess": 3.0})
+
+    image = np.zeros((4, 4, 3), dtype=np.uint8)
+    source_item = SourceItem(image=image, path="benchmark0")
+
+    monkeypatch.setattr(benchmark_cli, "_build_engine", lambda *_args, **_kwargs: _Engine())
+    monkeypatch.setattr(
+        "yoloe_tensorrt.source.normalize_source",
+        lambda *_args, **_kwargs: [source_item],
+    )
+
+    result = benchmark_cli.main(
+        [
+            str(tmp_path / "artifact"),
+            str(tmp_path / "image.jpg"),
+            "--mode",
+            "host",
+            "--runs",
+            "1",
+            "--warmup",
+            "0",
+            "--log-level",
+            "WARNING",
+        ]
+    )
+
+    assert result == 0

--- a/tests/test_engine_fast_path.py
+++ b/tests/test_engine_fast_path.py
@@ -10,25 +10,73 @@ from yoloe_tensorrt.inputs import PreparedTensorInput
 from yoloe_tensorrt.source import PreparedFrameMetadata, SourceItem
 
 
-def test_resolve_original_sample_uses_prepared_frame_metadata_shape() -> None:
+def test_resolve_original_image_path_uses_prepared_frame_metadata_shape() -> None:
     engine = object.__new__(YOLOEEngine)
     metadata = PreparedFrameMetadata(original_shape=(720, 1280), path="camera_frame000001")
 
-    sample = engine._resolve_original_sample(metadata, None, (320, 320))
+    original, path = engine._resolve_original_image_path(metadata, None, (320, 320))
 
-    assert sample.path == "camera_frame000001"
-    assert sample.original.shape == (720, 1280, 3)
+    assert path == "camera_frame000001"
+    assert original.shape == (720, 1280, 3)
+    assert original.flags.writeable
 
 
-def test_resolve_original_sample_prefers_prepared_frame_preview() -> None:
+def test_resolve_original_image_path_prefers_prepared_frame_preview() -> None:
     engine = object.__new__(YOLOEEngine)
     preview = torch.zeros((5, 7, 3), dtype=torch.uint8).numpy()
     metadata = PreparedFrameMetadata(original_shape=(5, 7), path="camera_frame000002", preview_image=preview)
 
-    sample = engine._resolve_original_sample(metadata, None, (320, 320))
+    original, path = engine._resolve_original_image_path(metadata, None, (320, 320))
 
-    assert sample.path == "camera_frame000002"
-    assert sample.original is preview
+    assert path == "camera_frame000002"
+    assert original is preview
+
+
+def test_resolve_original_image_path_returns_fresh_mutable_blank_fallback_images() -> None:
+    engine = object.__new__(YOLOEEngine)
+
+    first, first_path = engine._resolve_original_image_path(None, None, (320, 320))
+    second, second_path = engine._resolve_original_image_path(None, "tensor1", (320, 320))
+
+    assert first_path == "tensor0"
+    assert second_path == "tensor1"
+    assert first is not second
+    assert first.shape == (320, 320, 3)
+    assert first.flags.writeable
+    first[0, 0, 0] = 255
+    assert second[0, 0, 0] == 0
+
+
+def test_active_names_uses_prompt_name_cache_without_embedding_concat() -> None:
+    engine = object.__new__(YOLOEEngine)
+    engine._text_names = ["bus"]
+    engine._visual_names = ["person"]
+    engine._active_names_cache = ()
+    engine._active_prompt_embeddings = lambda: pytest.fail("active_names should not concatenate embeddings")  # type: ignore[method-assign]
+
+    assert engine.active_names == ["bus", "person"]
+    assert engine._active_names_cache == ("bus", "person")
+
+
+def test_main_output_names_are_cached_for_native_runtime() -> None:
+    class _FakeNativeRuntime:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        @property
+        def output_names(self) -> list[str]:
+            self.calls += 1
+            return ["predictions", "proto"]
+
+    fake_runtime = _FakeNativeRuntime()
+    engine = object.__new__(YOLOEEngine)
+    engine.native_main_runtime = fake_runtime
+    engine.main_runtime = None
+    engine._main_output_names_cache = ()
+
+    assert engine._main_output_names == ("predictions", "proto")
+    assert engine._main_output_names == ("predictions", "proto")
+    assert fake_runtime.calls == 1
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required for prepared-tensor stream handoff tests")
@@ -53,6 +101,8 @@ def test_prepared_fast_path_forwards_current_cuda_stream() -> None:
     engine = object.__new__(YOLOEEngine)
     engine.device = torch.device("cuda:0")
     engine.native_main_runtime = fake_runtime
+    engine._native_infer_tensor = fake_runtime.infer_tensor
+    engine._native_infer_tensor_postprocessed = None
     engine.main_runtime = None
     engine.metadata = SimpleNamespace()
     engine._text_prompt_embeddings = None
@@ -60,15 +110,19 @@ def test_prepared_fast_path_forwards_current_cuda_stream() -> None:
     engine._text_names = ["bus"]
     engine._visual_names = []
     engine._active_prompt_embeddings = lambda: (torch.zeros((1, 1, 512), device="cuda"), ["bus"])  # type: ignore[method-assign]
-    engine._resolve_original_sample = lambda original_image, path, input_shape: SimpleNamespace(  # type: ignore[method-assign]
-        original=original_image.image, path=path or original_image.path
-    )
     engine._postprocess_predictions = lambda **kwargs: Results(  # type: ignore[method-assign]
-        kwargs["sample"].original,
-        path=kwargs["sample"].path,
+        kwargs["original_image"],
+        path=kwargs["path"],
         names={0: "bus"},
         boxes=torch.zeros((0, 6), device="cpu"),
         speed=kwargs["speed"],
+    )
+    engine._build_native_legacy_result = lambda **kwargs: Results(  # type: ignore[method-assign]
+        kwargs["original_image"],
+        path=kwargs["path"],
+        names={0: "bus"},
+        boxes=torch.zeros((0, 6), device="cpu"),
+        speed={"preprocess": 0.0, "inference": 0.0, "postprocess": 0.0},
     )
 
     source_item = SourceItem(image=torch.zeros((8, 8, 3), dtype=torch.uint8).numpy(), path="frame0")
@@ -108,6 +162,8 @@ def test_prepared_fast_path_uses_captured_producer_stream_across_stream_contexts
     engine = object.__new__(YOLOEEngine)
     engine.device = torch.device("cuda:0")
     engine.native_main_runtime = fake_runtime
+    engine._native_infer_tensor = fake_runtime.infer_tensor
+    engine._native_infer_tensor_postprocessed = None
     engine.main_runtime = None
     engine.metadata = SimpleNamespace()
     engine._text_prompt_embeddings = None
@@ -115,12 +171,9 @@ def test_prepared_fast_path_uses_captured_producer_stream_across_stream_contexts
     engine._text_names = ["bus"]
     engine._visual_names = []
     engine._active_prompt_embeddings = lambda: (torch.zeros((1, 1, 512), device="cuda"), ["bus"])  # type: ignore[method-assign]
-    engine._resolve_original_sample = lambda original_image, path, input_shape: SimpleNamespace(  # type: ignore[method-assign]
-        original=original_image.image, path=path or original_image.path
-    )
     engine._postprocess_predictions = lambda **kwargs: Results(  # type: ignore[method-assign]
-        kwargs["sample"].original,
-        path=kwargs["sample"].path,
+        kwargs["original_image"],
+        path=kwargs["path"],
         names={0: "bus"},
         boxes=torch.zeros((0, 6), device="cpu"),
         speed=kwargs["speed"],
@@ -144,3 +197,70 @@ def test_prepared_fast_path_uses_captured_producer_stream_across_stream_contexts
     assert fake_runtime.calls
     _, _, _, producer_stream = fake_runtime.calls[-1]
     assert producer_stream == int(producer.cuda_stream)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required for prepared-tensor stream handoff tests")
+def test_prepared_fast_path_skips_current_stream_lookup_when_input_is_already_ready(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _FakeNativeRuntime:
+        output_names = ["predictions"]
+        fp16 = False
+
+        def __init__(self) -> None:
+            self.calls: list[tuple[int, int, int, int]] = []
+
+        def infer_tensor(self, image_ptr: int, target_h: int, target_w: int, producer_stream: int):
+            self.calls.append((image_ptr, target_h, target_w, producer_stream))
+            return {
+                "predictions": torch.zeros((1, 6, 1), device="cuda"),
+                "preprocess_ms": 0.0,
+                "inference_ms": 0.0,
+            }
+
+    fake_runtime = _FakeNativeRuntime()
+    engine = object.__new__(YOLOEEngine)
+    engine.device = torch.device("cuda:0")
+    engine.native_main_runtime = fake_runtime
+    engine._native_infer_tensor = fake_runtime.infer_tensor
+    engine._native_infer_tensor_postprocessed = None
+    engine.main_runtime = None
+    engine.metadata = SimpleNamespace()
+    engine._text_prompt_embeddings = None
+    engine._visual_prompt_embeddings = None
+    engine._text_names = ["bus"]
+    engine._visual_names = []
+    engine._active_names_cache = ()
+    engine._active_prompt_embeddings = lambda: (torch.zeros((1, 1, 512), device="cuda"), ["bus"])  # type: ignore[method-assign]
+    engine._postprocess_predictions = lambda **kwargs: Results(  # type: ignore[method-assign]
+        kwargs["original_image"],
+        path=kwargs["path"],
+        names={0: "bus"},
+        boxes=torch.zeros((0, 6), device="cpu"),
+        speed=kwargs["speed"],
+    )
+    engine._build_native_legacy_result = lambda **kwargs: Results(  # type: ignore[method-assign]
+        kwargs["original_image"],
+        path=kwargs["path"],
+        names={0: "bus"},
+        boxes=torch.zeros((0, 6), device="cpu"),
+        speed={"preprocess": 0.0, "inference": 0.0, "postprocess": 0.0},
+    )
+
+    producer_stream = 12345
+    prepared = PreparedTensorInput(
+        tensor=torch.zeros((1, 3, 8, 8), dtype=torch.float32, device="cuda"),
+        path="tensor0",
+        original_image=SourceItem(image=torch.zeros((8, 8, 3), dtype=torch.uint8).numpy(), path="tensor0"),
+        producer_stream=producer_stream,
+    )
+    monkeypatch.setattr(
+        torch.cuda,
+        "current_stream",
+        lambda *args, **kwargs: pytest.fail("current_stream should not be needed for ready prepared tensors"),
+    )
+
+    engine._predict_prepared_tensor(prepared, conf=0.25, iou=0.45, max_det=10, retina_masks=False)
+
+    assert fake_runtime.calls
+    assert fake_runtime.calls[-1][3] == producer_stream

--- a/tests/test_inputs.py
+++ b/tests/test_inputs.py
@@ -10,6 +10,7 @@ from yoloe_tensorrt.inputs import (
     PreparedTensorInput,
     iter_inference_sources,
     normalize_inference_source,
+    normalize_single_inference_source,
     validate_prepared_tensor,
 )
 from yoloe_tensorrt.preprocess import preprocess_image
@@ -206,3 +207,29 @@ def test_iter_inference_sources_allows_finite_live_sources_when_unbounded_live_d
     assert len(items) == 1
     assert isinstance(items[0], SourceItem)
     assert items[0].path == "frame0"
+
+
+def test_normalize_single_inference_source_returns_one_item() -> None:
+    item = normalize_single_inference_source(np.zeros((4, 4, 3), dtype=np.uint8))
+
+    assert isinstance(item, SourceItem)
+    assert item.path == "image0"
+
+
+def test_normalize_single_inference_source_rejects_empty_iterables() -> None:
+    with pytest.raises(ValueError, match="No images were found"):
+        normalize_single_inference_source([])
+
+
+def test_normalize_single_inference_source_rejects_multiple_items_lazily() -> None:
+    consumed = {"count": 0}
+
+    def _source():
+        for _ in range(3):
+            consumed["count"] += 1
+            yield np.zeros((4, 4, 3), dtype=np.uint8)
+
+    with pytest.raises(ValueError, match="single frame"):
+        normalize_single_inference_source(_source(), multiple_error="single frame")
+
+    assert consumed["count"] == 2

--- a/tests/test_runtime_integration.py
+++ b/tests/test_runtime_integration.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from pathlib import Path
-from types import SimpleNamespace
 
 import numpy as np
 import pytest
@@ -117,7 +116,8 @@ def _python_reference_from_native_image_outputs(
     }
     return runtime_engine._postprocess_predictions(
         outputs=outputs,
-        sample=SimpleNamespace(original=item.image, path=item.path),
+        original_image=item.image,
+        path=item.path,
         input_shape=tuple(int(v) for v in native_outputs["input_shape"]),
         names=labels,
         conf=conf,
@@ -152,7 +152,11 @@ def _python_reference_from_native_tensor_outputs(
         producer_stream,
     )
     outputs = {name: from_dlpack(native_outputs[name]) for name in runtime_engine._main_output_names}
-    sample = runtime_engine._resolve_original_sample(prepared.original_image, prepared.path, input_shape)
+    original_image, path = runtime_engine._resolve_original_image_path(
+        prepared.original_image,
+        prepared.path,
+        input_shape,
+    )
     speed = {
         "preprocess": float(native_outputs["preprocess_ms"]),
         "inference": float(native_outputs["inference_ms"]),
@@ -160,7 +164,8 @@ def _python_reference_from_native_tensor_outputs(
     }
     return runtime_engine._postprocess_predictions(
         outputs=outputs,
-        sample=sample,
+        original_image=original_image,
+        path=path,
         input_shape=tuple(int(v) for v in native_outputs["input_shape"]),
         names=labels,
         conf=conf,

--- a/yoloe_tensorrt/benchmark_cli.py
+++ b/yoloe_tensorrt/benchmark_cli.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
 import argparse
+import gc
 import logging
+import math
 import statistics
 import time
+import tracemalloc
 from contextlib import contextmanager
 from pathlib import Path
+from typing import Callable
 
 import numpy as np
 
@@ -40,6 +44,22 @@ def build_arg_parser() -> argparse.ArgumentParser:
     parser.add_argument("--conf", type=float, default=0.25, help="Detection confidence threshold.")
     parser.add_argument("--device", default="cuda:0", help="Torch/TensorRT device. Defaults to cuda:0.")
     parser.add_argument(
+        "--track",
+        action="store_true",
+        help="Benchmark tracker session update() instead of raw prediction.",
+    )
+    parser.add_argument(
+        "--profile-allocations",
+        action="store_true",
+        help="Profile retained Python allocations and traced peak memory across the measured loop.",
+    )
+    parser.add_argument(
+        "--allocation-top",
+        type=int,
+        default=5,
+        help="Number of allocation hot spots to print when --profile-allocations is enabled.",
+    )
+    parser.add_argument(
         "--visual-prompts",
         choices=("none", "bbox", "mask", "both"),
         default="none",
@@ -56,23 +76,123 @@ def build_arg_parser() -> argparse.ArgumentParser:
 
 
 def _format_ms(values: list[float]) -> str:
+    sorted_values = sorted(values)
+    stdev = statistics.pstdev(values) if len(values) > 1 else 0.0
+    p95 = _nearest_rank_percentile(sorted_values, 0.95)
+    p99 = _nearest_rank_percentile(sorted_values, 0.99)
     return (
         f"mean={statistics.fmean(values):.2f}ms "
         f"median={statistics.median(values):.2f}ms "
-        f"p95={sorted(values)[max(0, int(len(values) * 0.95) - 1)]:.2f}ms"
+        f"p95={p95:.2f}ms "
+        f"p99={p99:.2f}ms "
+        f"stdev={stdev:.2f}ms"
     )
 
 
-def _summarize_result_speeds(name: str, speeds: list[dict[str, float]]) -> None:
-    if not speeds:
+def _nearest_rank_percentile(sorted_values: list[float], percentile: float) -> float:
+    index = min(len(sorted_values) - 1, max(0, math.ceil(len(sorted_values) * percentile) - 1))
+    return sorted_values[index]
+
+
+def _summarize_result_speeds(
+    name: str,
+    preprocess: list[float],
+    inference: list[float],
+    postprocess: list[float],
+) -> None:
+    if not preprocess:
         return
-    preprocess = [speed["preprocess"] for speed in speeds]
-    inference = [speed["inference"] for speed in speeds]
-    postprocess = [speed["postprocess"] for speed in speeds]
     print(
         f"{name} speed breakdown: preprocess={statistics.fmean(preprocess):.2f}ms "
         f"inference={statistics.fmean(inference):.2f}ms postprocess={statistics.fmean(postprocess):.2f}ms"
     )
+
+
+def _format_bytes(value: int) -> str:
+    if value < 1024:
+        return f"{value}B"
+    if value < 1024 * 1024:
+        return f"{value / 1024.0:.1f}KiB"
+    return f"{value / (1024.0 * 1024.0):.1f}MiB"
+
+
+def _print_allocation_summary(
+    name: str,
+    before: tracemalloc.Snapshot,
+    after: tracemalloc.Snapshot,
+    peak_bytes: int,
+    top_n: int,
+) -> None:
+    stats = [stat for stat in after.compare_to(before, "lineno") if stat.size_diff > 0 or stat.count_diff > 0]
+    retained_bytes = sum(max(0, stat.size_diff) for stat in stats)
+    retained_count = sum(max(0, stat.count_diff) for stat in stats)
+    print(
+        f"{name} Python retained allocations: retained={_format_bytes(retained_bytes)} "
+        f"count={retained_count} peak_traced={_format_bytes(peak_bytes)}"
+    )
+    for index, stat in enumerate(stats[: max(0, int(top_n))], start=1):
+        frame = stat.traceback[0]
+        print(
+            f"{name} retained allocation hotspot {index}: {frame.filename}:{frame.lineno} "
+            f"size={_format_bytes(max(0, stat.size_diff))} count={max(0, stat.count_diff)}"
+        )
+
+
+def _benchmark_runner(
+    name: str,
+    runner: Callable[[], object],
+    *,
+    runs: int,
+    warmup: int,
+    profile_allocations: bool,
+    allocation_top: int,
+) -> None:
+    for _ in range(warmup):
+        runner()
+
+    latencies_ms = [0.0] * runs
+    preprocess = [0.0] * runs
+    inference = [0.0] * runs
+    postprocess = [0.0] * runs
+
+    before_snapshot = None
+    peak_bytes = 0
+    gc_was_enabled = gc.isenabled()
+    if profile_allocations:
+        gc.collect()
+        gc.disable()
+        tracemalloc.start()
+        before_snapshot = tracemalloc.take_snapshot()
+
+    result = None
+    speed = None
+    try:
+        for index in range(runs):
+            start = time.perf_counter()
+            result = runner()
+            latencies_ms[index] = (time.perf_counter() - start) * 1000.0
+            speed = getattr(result, "speed", {})
+            preprocess[index] = float(speed.get("preprocess") or 0.0)
+            inference[index] = float(speed.get("inference") or 0.0)
+            postprocess[index] = float(speed.get("postprocess") or 0.0)
+    finally:
+        result = None
+        speed = None
+        if profile_allocations:
+            _, peak_bytes = tracemalloc.get_traced_memory()
+            after_snapshot = tracemalloc.take_snapshot()
+            tracemalloc.stop()
+            if gc_was_enabled:
+                gc.enable()
+            else:
+                gc.disable()
+
+    fps = 1000.0 / statistics.fmean(latencies_ms)
+    print(f"{name}: runs={runs} {_format_ms(latencies_ms)} fps={fps:.2f}")
+    _summarize_result_speeds(name, preprocess, inference, postprocess)
+    if profile_allocations:
+        assert before_snapshot is not None
+        _print_allocation_summary(name, before_snapshot, after_snapshot, peak_bytes, allocation_top)
 
 
 def _build_engine(artifact_dir: Path, device: str, *, disable_native_visual: bool = False):
@@ -145,35 +265,46 @@ def main(argv: list[str] | None = None) -> int:
     engine.set_classes(labels)
 
     item = normalize_source(Path(args.image), default_prefix="benchmark")[0]
-    prepared_input = engine.prepare_cuda_input(item, imgsz=target_size)
+    host_tracker = engine.create_tracker() if args.track and args.mode in {"host", "both"} else None
 
     def _run_host():
+        if host_tracker is not None:
+            return host_tracker.update(item, source_key="benchmark", imgsz=target_size, conf=float(args.conf))
         return engine.predict_item(item, imgsz=target_size, conf=float(args.conf))
 
-    def _run_cuda():
-        return engine.predict(prepared_input, conf=float(args.conf))[0]
-
-    runners = []
     if args.mode in {"host", "both"}:
-        runners.append(("host", _run_host))
+        _benchmark_runner(
+            "host-track" if args.track else "host",
+            _run_host,
+            runs=int(args.runs),
+            warmup=int(args.warmup),
+            profile_allocations=bool(args.profile_allocations),
+            allocation_top=int(args.allocation_top),
+        )
+
     if args.mode in {"cuda", "both"}:
-        runners.append(("cuda", _run_cuda))
+        prepared_input = engine.prepare_cuda_input(item, imgsz=target_size)
+        cuda_tracker = engine.create_tracker() if args.track else None
 
-    for name, runner in runners:
-        for _ in range(int(args.warmup)):
-            runner()
+        def _run_cuda():
+            if cuda_tracker is not None:
+                return cuda_tracker.update(
+                    prepared_input,
+                    source_key="benchmark",
+                    conf=float(args.conf),
+                    input_hint="prepared",
+                    cuda=True,
+                )
+            return engine.predict(prepared_input, conf=float(args.conf))[0]
 
-        latencies_ms: list[float] = []
-        speeds: list[dict[str, float]] = []
-        for _ in range(int(args.runs)):
-            start = time.perf_counter()
-            result = runner()
-            latencies_ms.append((time.perf_counter() - start) * 1000.0)
-            speeds.append(dict(result.speed))
-
-        fps = 1000.0 / statistics.fmean(latencies_ms)
-        print(f"{name}: runs={int(args.runs)} {_format_ms(latencies_ms)} fps={fps:.2f}")
-        _summarize_result_speeds(name, speeds)
+        _benchmark_runner(
+            "cuda-track" if args.track else "cuda",
+            _run_cuda,
+            runs=int(args.runs),
+            warmup=int(args.warmup),
+            profile_allocations=bool(args.profile_allocations),
+            allocation_top=int(args.allocation_top),
+        )
 
     if args.visual_prompts != "none":
         visual_prompt_inputs = _build_visual_prompt_inputs(item.image, labels[0])

--- a/yoloe_tensorrt/engine.py
+++ b/yoloe_tensorrt/engine.py
@@ -2,8 +2,7 @@ from __future__ import annotations
 
 import time
 from pathlib import Path
-from types import SimpleNamespace
-from typing import Callable, Iterator
+from typing import Iterator, Sequence
 
 import numpy as np
 import torch
@@ -71,7 +70,18 @@ class YOLOEEngine:
         self._visual_prompt_embeddings: torch.Tensor | None = None
         self._text_names: list[str] = []
         self._visual_names: list[str] = []
+        self._active_names_cache: tuple[str, ...] = ()
         self._prompt_generation = 0
+        self._native_infer_image = getattr(native_main_runtime, "infer_image", None)
+        self._native_infer_tensor = getattr(native_main_runtime, "infer_tensor", None)
+        self._native_infer_image_postprocessed = getattr(native_main_runtime, "infer_image_postprocessed", None)
+        self._native_infer_tensor_postprocessed = getattr(native_main_runtime, "infer_tensor_postprocessed", None)
+        if native_main_runtime is not None:
+            self._main_output_names_cache: tuple[str, ...] = tuple(native_main_runtime.output_names)
+        elif main_runtime is not None:
+            self._main_output_names_cache = tuple(main_runtime.output_names)
+        else:
+            self._main_output_names_cache = ()
         LOGGER.info(
             "Initialized YOLOEEngine with artifact_dir='%s', task=%s, device=%s native=%s",
             self.artifact_dir,
@@ -193,19 +203,29 @@ class YOLOEEngine:
             self._visual_names,
         )
 
-    def _active_prompt_names(self) -> list[str]:
-        names = [*self._text_names, *self._visual_names]
+    def _active_prompt_names(self) -> tuple[str, ...]:
+        names = getattr(self, "_active_names_cache", ())
         if not names:
-            raise RuntimeError("No prompt embeddings are active. Call set_classes() or set_visual_prompts() first.")
+            names = (*self._text_names, *self._visual_names)
+            if not names:
+                raise RuntimeError("No prompt embeddings are active. Call set_classes() or set_visual_prompts() first.")
+            self._active_names_cache = names
         return names
 
     @property
-    def _main_output_names(self) -> list[str]:
+    def _main_output_names(self) -> tuple[str, ...]:
+        cached = getattr(self, "_main_output_names_cache", ())
+        if cached:
+            return cached
         if self.native_main_runtime is not None:
-            return list(self.native_main_runtime.output_names)
+            cached = tuple(self.native_main_runtime.output_names)
+            self._main_output_names_cache = cached
+            return cached
         if self.main_runtime is None:
             raise RuntimeError("Main runtime is not initialized")
-        return self.main_runtime.output_names
+        cached = tuple(self.main_runtime.output_names)
+        self._main_output_names_cache = cached
+        return cached
 
     @property
     def _main_fp16(self) -> bool:
@@ -242,6 +262,7 @@ class YOLOEEngine:
 
     def _bump_prompt_generation(self) -> None:
         self._prompt_generation += 1
+        self._active_names_cache = ()
 
     def _describe_source(self, source: object) -> str:
         if isinstance(source, SourceItem):
@@ -424,17 +445,17 @@ class YOLOEEngine:
     @property
     def active_names(self) -> list[str]:
         try:
-            _, names = self._active_prompt_embeddings()
-            return names
+            return list(self._active_prompt_names())
         except RuntimeError:
             return []
 
     def _postprocess_predictions(
         self,
         outputs: dict[str, torch.Tensor],
-        sample,
+        original_image: np.ndarray,
+        path: str,
         input_shape: tuple[int, int],
-        names: list[str],
+        names: Sequence[str],
         conf: float,
         iou: float,
         max_det: int,
@@ -458,22 +479,20 @@ class YOLOEEngine:
             if preds.shape[0] == 0:
                 masks = None
             elif retina_masks:
-                preds[:, :4] = ops.scale_boxes(input_shape, preds[:, :4], sample.original.shape)
-                masks = ops.process_mask_native(proto, preds[:, 6:], preds[:, :4], sample.original.shape[:2])
+                preds[:, :4] = ops.scale_boxes(input_shape, preds[:, :4], original_image.shape)
+                masks = ops.process_mask_native(proto, preds[:, 6:], preds[:, :4], original_image.shape[:2])
             else:
                 masks = ops.process_mask(proto, preds[:, 6:], preds[:, :4], input_shape, upsample=True)
-                preds[:, :4] = ops.scale_boxes(input_shape, preds[:, :4], sample.original.shape)
+                preds[:, :4] = ops.scale_boxes(input_shape, preds[:, :4], original_image.shape)
             if masks is not None:
                 keep = masks.amax((-2, -1)) > 0
                 if not bool(torch.all(keep)):
                     preds = preds[keep]
                     masks = masks[keep]
-            return Results(
-                sample.original, path=sample.path, names=names_map, boxes=preds[:, :6], masks=masks, speed=speed
-            )
+            return Results(original_image, path=path, names=names_map, boxes=preds[:, :6], masks=masks, speed=speed)
 
-        preds[:, :4] = ops.scale_boxes(input_shape, preds[:, :4], sample.original.shape)
-        return Results(sample.original, path=sample.path, names=names_map, boxes=preds[:, :6], speed=speed)
+        preds[:, :4] = ops.scale_boxes(input_shape, preds[:, :4], original_image.shape)
+        return Results(original_image, path=path, names=names_map, boxes=preds[:, :6], speed=speed)
 
     def _predict_one(
         self,
@@ -495,36 +514,46 @@ class YOLOEEngine:
             len(names),
             imgsz,
         )
-        preprocess_start = time.perf_counter()
-        sample = SimpleNamespace(original=item.image, path=item.path)
         if self.native_main_runtime is not None:
-            result = self._run_native_result(
-                sample=sample,
-                names=names,
-                conf=conf,
-                iou=iou,
-                max_det=max_det,
-                retina_masks=retina_masks,
-                raw_call=lambda: self.native_main_runtime.infer_image(item.image, imgsz[0], imgsz[1]),
-                postprocessed_call=(
-                    lambda: self.native_main_runtime.infer_image_postprocessed(
-                        item.image,
-                        imgsz[0],
-                        imgsz[1],
-                        int(item.image.shape[0]),
-                        int(item.image.shape[1]),
-                        float(conf),
-                        float(iou),
-                        int(max_det),
-                        bool(retina_masks),
-                    )
+            native_infer_image_postprocessed = self._native_infer_image_postprocessed
+            if native_infer_image_postprocessed is not None:
+                native_outputs = native_infer_image_postprocessed(
+                    item.image,
+                    imgsz[0],
+                    imgsz[1],
+                    int(item.image.shape[0]),
+                    int(item.image.shape[1]),
+                    float(conf),
+                    float(iou),
+                    int(max_det),
+                    bool(retina_masks),
                 )
-                if hasattr(self.native_main_runtime, "infer_image_postprocessed")
-                else None,
-            )
+                result = self._build_native_postprocessed_result(
+                    native_outputs=native_outputs,
+                    original_image=item.image,
+                    path=item.path,
+                    names=names,
+                    preprocess_ms=float(native_outputs["preprocess_ms"]),
+                    inference_ms=float(native_outputs["inference_ms"]),
+                )
+            else:
+                native_infer_image = self._native_infer_image
+                if native_infer_image is None:
+                    raise RuntimeError("Native main runtime does not support image inference")
+                result = self._build_native_legacy_result(
+                    native_outputs=native_infer_image(item.image, imgsz[0], imgsz[1]),
+                    original_image=item.image,
+                    path=item.path,
+                    names=names,
+                    conf=conf,
+                    iou=iou,
+                    max_det=max_det,
+                    retina_masks=retina_masks,
+                )
         else:
             if self.main_runtime is None:
                 raise RuntimeError("Main runtime is not initialized")
+            preprocess_start = time.perf_counter()
             sample = preprocess_image(
                 item,
                 imgsz=imgsz,
@@ -548,7 +577,8 @@ class YOLOEEngine:
             speed = {"preprocess": preprocess_ms, "inference": inference_ms, "postprocess": 0.0}
             result = self._postprocess_predictions(
                 outputs=outputs,
-                sample=sample,
+                original_image=sample.original,
+                path=sample.path,
                 input_shape=input_shape,
                 names=names,
                 conf=conf,
@@ -570,33 +600,32 @@ class YOLOEEngine:
         )
         return result
 
-    def _resolve_original_sample(
+    def _resolve_original_image_path(
         self,
         original_image: SourceItem | PreparedFrameMetadata | object | None,
         path: str | None,
         input_shape: tuple[int, int],
-    ) -> SimpleNamespace:
+    ) -> tuple[np.ndarray, str]:
         if isinstance(original_image, SourceItem):
-            return SimpleNamespace(original=original_image.image, path=path or original_image.path)
+            return original_image.image, path or original_image.path
         if isinstance(original_image, PreparedFrameMetadata):
             resolved_path = path or original_image.path or "tensor0"
             if original_image.preview_image is not None:
-                return SimpleNamespace(original=original_image.preview_image, path=resolved_path)
-            fallback_image = np.zeros((*original_image.original_shape, 3), dtype=np.uint8)
-            return SimpleNamespace(original=fallback_image, path=resolved_path)
+                return original_image.preview_image, resolved_path
+            return np.zeros((*original_image.original_shape, 3), dtype=np.uint8), resolved_path
         if original_image is not None:
             item = normalize_source(original_image, default_prefix="tensor")[0]
-            return SimpleNamespace(original=item.image, path=path or item.path)
+            return item.image, path or item.path
 
         fallback_path = path or "tensor0"
-        fallback_image = np.zeros((input_shape[0], input_shape[1], 3), dtype=np.uint8)
-        return SimpleNamespace(original=fallback_image, path=fallback_path)
+        return np.zeros((input_shape[0], input_shape[1], 3), dtype=np.uint8), fallback_path
 
     def _build_native_postprocessed_result(
         self,
         native_outputs: dict[str, object],
-        sample,
-        names: list[str],
+        original_image: np.ndarray,
+        path: str,
+        names: Sequence[str],
         preprocess_ms: float,
         inference_ms: float,
     ) -> Results:
@@ -608,13 +637,14 @@ class YOLOEEngine:
         names_map = {index: name for index, name in enumerate(names)}
         boxes = from_dlpack(native_outputs["boxes"])
         masks = from_dlpack(native_outputs["masks"]) if "masks" in native_outputs else None
-        return Results(sample.original, path=sample.path, names=names_map, boxes=boxes, masks=masks, speed=speed)
+        return Results(original_image, path=path, names=names_map, boxes=boxes, masks=masks, speed=speed)
 
     def _build_native_legacy_result(
         self,
         native_outputs: dict[str, object],
-        sample,
-        names: list[str],
+        original_image: np.ndarray,
+        path: str,
+        names: Sequence[str],
         conf: float,
         iou: float,
         max_det: int,
@@ -633,7 +663,8 @@ class YOLOEEngine:
         postprocess_start = time.perf_counter()
         result = self._postprocess_predictions(
             outputs=outputs,
-            sample=sample,
+            original_image=original_image,
+            path=path,
             input_shape=resolved_input_shape,
             names=names,
             conf=conf,
@@ -645,39 +676,6 @@ class YOLOEEngine:
         speed["postprocess"] = (time.perf_counter() - postprocess_start) * 1000.0
         result.speed = speed
         return result
-
-    def _run_native_result(
-        self,
-        sample,
-        names: list[str],
-        conf: float,
-        iou: float,
-        max_det: int,
-        retina_masks: bool,
-        *,
-        input_shape: tuple[int, int] | None = None,
-        raw_call: Callable[[], dict[str, object]],
-        postprocessed_call: Callable[[], dict[str, object]] | None = None,
-    ) -> Results:
-        if postprocessed_call is not None:
-            native_outputs = postprocessed_call()
-            return self._build_native_postprocessed_result(
-                native_outputs=native_outputs,
-                sample=sample,
-                names=names,
-                preprocess_ms=float(native_outputs["preprocess_ms"]),
-                inference_ms=float(native_outputs["inference_ms"]),
-            )
-        return self._build_native_legacy_result(
-            native_outputs=raw_call(),
-            sample=sample,
-            names=names,
-            conf=conf,
-            iou=iou,
-            max_det=max_det,
-            retina_masks=retina_masks,
-            input_shape=input_shape,
-        )
 
     def _predict_prepared_tensor(
         self,
@@ -702,56 +700,77 @@ class YOLOEEngine:
                 "Prepared tensor inputs must have shape (3, H, W) or (1, 3, H, W) before they enter the fast path"
             )
 
-        current_stream = int(torch.cuda.current_stream(self.device).cuda_stream)
+        current_stream: int | None = None
         producer_stream = item.producer_stream
         if image_tensor.device.type != "cuda":
             image_tensor = image_tensor.to(device=self.device)
+            current_stream = int(torch.cuda.current_stream(self.device).cuda_stream)
             producer_stream = current_stream
         elif image_tensor.device != self.device:
             image_tensor = image_tensor.to(device=self.device)
+            current_stream = int(torch.cuda.current_stream(self.device).cuda_stream)
             producer_stream = current_stream
         target_dtype = torch.float16 if self._main_fp16 else torch.float32
         if image_tensor.dtype != target_dtype:
             image_tensor = image_tensor.to(dtype=target_dtype)
+            if current_stream is None:
+                current_stream = int(torch.cuda.current_stream(self.device).cuda_stream)
             producer_stream = current_stream
-        contiguous_tensor = image_tensor.contiguous()
-        if contiguous_tensor.data_ptr() != image_tensor.data_ptr():
+        if not image_tensor.is_contiguous():
+            image_tensor = image_tensor.contiguous()
+            if current_stream is None:
+                current_stream = int(torch.cuda.current_stream(self.device).cuda_stream)
             producer_stream = current_stream
-        image_tensor = contiguous_tensor
         if producer_stream is None:
+            if current_stream is None:
+                current_stream = int(torch.cuda.current_stream(self.device).cuda_stream)
             producer_stream = current_stream
 
         input_shape = (int(image_tensor.shape[2]), int(image_tensor.shape[3]))
-        sample = self._resolve_original_sample(item.original_image, item.path, input_shape)
+        original_image, result_path = self._resolve_original_image_path(item.original_image, item.path, input_shape)
         if self.native_main_runtime is not None:
-            result = self._run_native_result(
-                sample=sample,
-                names=names,
-                conf=conf,
-                iou=iou,
-                max_det=max_det,
-                retina_masks=retina_masks,
-                input_shape=input_shape,
-                raw_call=lambda: self.native_main_runtime.infer_tensor(
-                    int(image_tensor.data_ptr()), input_shape[0], input_shape[1], producer_stream
-                ),
-                postprocessed_call=(
-                    lambda: self.native_main_runtime.infer_tensor_postprocessed(
+            native_infer_tensor_postprocessed = self._native_infer_tensor_postprocessed
+            if native_infer_tensor_postprocessed is not None:
+                native_outputs = native_infer_tensor_postprocessed(
+                    int(image_tensor.data_ptr()),
+                    input_shape[0],
+                    input_shape[1],
+                    int(original_image.shape[0]),
+                    int(original_image.shape[1]),
+                    float(conf),
+                    float(iou),
+                    int(max_det),
+                    bool(retina_masks),
+                    producer_stream,
+                )
+                result = self._build_native_postprocessed_result(
+                    native_outputs=native_outputs,
+                    original_image=original_image,
+                    path=result_path,
+                    names=names,
+                    preprocess_ms=float(native_outputs["preprocess_ms"]),
+                    inference_ms=float(native_outputs["inference_ms"]),
+                )
+            else:
+                native_infer_tensor = self._native_infer_tensor
+                if native_infer_tensor is None:
+                    raise RuntimeError("Native main runtime does not support tensor inference")
+                result = self._build_native_legacy_result(
+                    native_outputs=native_infer_tensor(
                         int(image_tensor.data_ptr()),
                         input_shape[0],
                         input_shape[1],
-                        int(sample.original.shape[0]),
-                        int(sample.original.shape[1]),
-                        float(conf),
-                        float(iou),
-                        int(max_det),
-                        bool(retina_masks),
                         producer_stream,
-                    )
+                    ),
+                    original_image=original_image,
+                    path=result_path,
+                    names=names,
+                    conf=conf,
+                    iou=iou,
+                    max_det=max_det,
+                    retina_masks=retina_masks,
+                    input_shape=input_shape,
                 )
-                if hasattr(self.native_main_runtime, "infer_tensor_postprocessed")
-                else None,
-            )
         else:
             if self.main_runtime is None:
                 raise RuntimeError("Main runtime is not initialized")
@@ -769,7 +788,8 @@ class YOLOEEngine:
             speed = {"preprocess": preprocess_ms, "inference": inference_ms, "postprocess": 0.0}
             result = self._postprocess_predictions(
                 outputs=outputs,
-                sample=sample,
+                original_image=original_image,
+                path=result_path,
                 input_shape=input_shape,
                 names=names,
                 conf=conf,
@@ -783,7 +803,7 @@ class YOLOEEngine:
         LOGGER.debug(
             "Completed prepared-tensor inference on '%s': input_shape=%s detections=%d "
             "pre=%.1fms inf=%.1fms post=%.1fms",
-            sample.path,
+            result_path,
             input_shape,
             int(result.boxes.data.shape[0]) if result.boxes is not None else 0,
             result.speed["preprocess"],

--- a/yoloe_tensorrt/inputs.py
+++ b/yoloe_tensorrt/inputs.py
@@ -86,6 +86,37 @@ def normalize_inference_source(
     return items
 
 
+def normalize_single_inference_source(
+    source: object,
+    *,
+    default_prefix: str = "image",
+    input_hint: str | None = None,
+    cuda: bool | None = None,
+    original_image: SourceItem | object | None = None,
+    path: str | None = None,
+    multiple_error: str = "Expected a single inference source item",
+) -> InferenceSourceItem:
+    items = iter_inference_sources(
+        source,
+        default_prefix=default_prefix,
+        input_hint=input_hint,
+        cuda=cuda,
+        allow_unbounded_live=False,
+        original_image=original_image,
+        path=path,
+    )
+    try:
+        first = next(items)
+    except StopIteration as exc:
+        raise ValueError("No images were found in the provided source") from exc
+    try:
+        next(items)
+    except StopIteration:
+        LOGGER.debug("Normalized 1 inference source item")
+        return first
+    raise ValueError(multiple_error)
+
+
 def iter_inference_sources(
     source: object,
     *,

--- a/yoloe_tensorrt/tracking.py
+++ b/yoloe_tensorrt/tracking.py
@@ -4,12 +4,13 @@ from copy import deepcopy
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+import numpy as np
 import torch
 import yaml
 from ultralytics.engine.results import Results
 from ultralytics.utils import IterableSimpleNamespace
 
-from .inputs import InferenceSourceItem, PreparedTensorInput, normalize_inference_source
+from .inputs import InferenceSourceItem, PreparedTensorInput, normalize_single_inference_source
 from .logging_utils import get_logger
 from .source import SourceItem
 
@@ -116,7 +117,10 @@ def _apply_tracking_to_result(result: Results, tracker_backend) -> Results:
     if len(tracks) == 0:
         return result
 
-    keep_indices = tracks[:, -1].astype(int).tolist()
+    keep_indices_np = tracks[:, -1].astype(np.int64, copy=False)
+    keep_indices = keep_indices_np
+    if torch.is_tensor(result.boxes.data) and result.boxes.data.device.type != "cpu":
+        keep_indices = torch.as_tensor(keep_indices_np, device=result.boxes.data.device)
     tracked_result = result[keep_indices]
     dtype = result.boxes.data.dtype if torch.is_tensor(result.boxes.data) else torch.float32
     tracked_boxes = torch.as_tensor(tracks[:, :-1], dtype=dtype)
@@ -190,18 +194,17 @@ class YOLOETrackerSession:
     ) -> Results:
         self._reset_if_needed(source_key)
         resolved_max_det = int(max_det or self.engine.metadata.max_det)
-        items = normalize_inference_source(
+        item = normalize_single_inference_source(
             frame,
             default_prefix="frame",
             input_hint=input_hint,
             cuda=cuda,
             original_image=original_image,
             path=path,
+            multiple_error="YOLOETrackerSession.update expects a single frame input",
         )
-        if len(items) != 1:
-            raise ValueError("YOLOETrackerSession.update expects a single frame input")
         result = self.engine._predict_input_entry(
-            item=items[0],
+            item=item,
             imgsz=imgsz,
             conf=conf,
             iou=iou,


### PR DESCRIPTION
  - Reduced steady-state Python allocations in predict() and track() hot paths.
  - Cached active prompt names, native inference method handles, and main output names.
  - Removed per-result SimpleNamespace wrappers from postprocess/native result construction.
  - Avoided unnecessary prepared-tensor .contiguous() calls and CUDA current-stream lookups when inputs are already ready.
  - Added lazy single-frame normalization for tracker session updates.
  - Reduced tracking allocation churn by avoiding .tolist() in tracked result indexing.
  - Expanded benchmark CLI with tracking mode, retained-allocation profiling, p95/p99/stdev latency reporting, and isolated host/CUDA setup.
  - Added regression tests for allocation-sensitive paths, benchmark math, host-only benchmark isolation, prepared tensor routing, and cached native metadata.