### PR TITLE
feat: added Jetson performance regression benchmarks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Unified `predict(...)` and `track(...)` around a single broad input surface with specialized internal routing for paths, arrays, raw tensors, prepared CUDA tensors, and live sources.
 - Added `PreparedTensorInput`, a prepared CUDA-tensor fast path, and a `benchmark` CLI for comparing host-image and CUDA-tensor inference through the native TensorRT runtime.
+- Added reproducible Jetson benchmark output with JSON result files, CPU utilization metrics, camera-path timing, and optional baseline comparison.
 - Extended tracker sessions to use the unified input router, support prepared tensor updates, and preserve the artifact default `max_det` behavior.
 - Fixed prepared-tensor correctness issues around integer dtype validation, CUDA producer-stream handoff, and cross-stream prepared-tensor inference.
 - Fixed unit-range float preprocessing so non-square padded inputs keep the correct scale instead of being divided by `255` a second time.

--- a/README.md
+++ b/README.md
@@ -180,7 +180,15 @@ scripts/launch_camera_gui.sh
 Benchmark host-image vs CUDA-tensor paths:
 
 ```bash
-yoloe-benchmark outputs/artifacts/yoloe26s tests/assets/images/bus.jpg --label bus --mode both
+yoloe-benchmark outputs/artifacts/yoloe26s tests/assets/images/bus.jpg \
+  --label bus --mode both --runs 200 --warmup 20
+```
+
+Benchmark a Jetson camera source and save structured results under `outputs/benchmarks/`:
+
+```bash
+yoloe-benchmark outputs/artifacts/yoloe26s tests/assets/images/bus.jpg \
+  --label bus --mode camera --camera-source /dev/video0 --camera-zero-copy auto
 ```
 
 ## CI/CD
@@ -227,6 +235,7 @@ GitHub Actions is the supported automation path for this repository.
 - [Quickstart](docs/quickstart.md)
 - [Export and Artifact Bundles](docs/export.md)
 - [Runtime Prompts](docs/prompts.md)
+- [Benchmarks](docs/benchmarks.md)
 - [Camera GUI](docs/camera-gui.md)
 - [Troubleshooting](docs/troubleshooting.md)
 - [Development](docs/development.md)

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -1,0 +1,49 @@
+# Benchmarks
+
+`yoloe-benchmark` measures runtime inference paths and writes structured JSON output under `outputs/benchmarks/` by
+default. It reports latency, FPS, measured-loop process CPU utilization, and measured-loop total system CPU utilization
+for each measured path.
+
+## Host and CUDA paths
+
+```bash
+yoloe-benchmark outputs/artifacts/yoloe26s tests/assets/images/bus.jpg \
+  --label bus --mode both --runs 200 --warmup 20
+```
+
+`--mode both` preserves the historical behavior and runs only the host-memory image path plus the prepared CUDA tensor
+path.
+
+## Jetson camera path
+
+```bash
+yoloe-benchmark outputs/artifacts/yoloe26s tests/assets/images/bus.jpg \
+  --label bus --mode camera --camera-source /dev/video0 \
+  --camera-zero-copy auto --runs 200 --warmup 20
+```
+
+Camera mode opens the live source once and consumes `warmup + runs` frames. Use `--camera-zero-copy required` when the
+benchmark must fail instead of falling back to the CPU appsink path.
+
+## JSON output
+
+Each JSON file contains:
+
+- `schema_version`, `created_at`, `package_version`, and platform metadata
+- `config` with artifact, labels, image size, run counts, tracking, and camera settings
+- `results` keyed by mode, with `latency_ms`, `fps`, `speed_ms`, `cpu`, and optional `allocations`
+
+Disable file output with `--no-save`, or choose the location with `--output-dir` and `--output-name`.
+
+## Baseline comparison
+
+```bash
+yoloe-benchmark outputs/artifacts/yoloe26s tests/assets/images/bus.jpg \
+  --label bus --mode all --camera-source /dev/video0 \
+  --compare-to outputs/benchmarks/<baseline>.json
+```
+
+Comparison mode checks only modes present in both result files. It reports latency and CPU increases plus FPS decreases.
+If no modes overlap, the comparison is reported as `no_overlap`; if overlapping modes have no comparable metrics, it is
+reported as `no_comparable_metrics`. Add `--fail-on-regression` to exit non-zero when a configured threshold is exceeded
+or when the comparison is invalid.

--- a/docs/development.md
+++ b/docs/development.md
@@ -58,11 +58,32 @@ python -m pytest -s -o log_cli=true --log-cli-level=INFO \
 
 The public API is unified around `YOLOEEngine.predict(...)` and `YOLOEEngine.track(...)`, but the lowest-overhead headless
 route is still the prepared-tensor path returned by `YOLOEEngine.prepare_cuda_input(...)`. Benchmark host-image vs
-prepared-tensor inference with:
+prepared-tensor inference with JSON output under `outputs/benchmarks/`:
 
 ```bash
-yoloe-benchmark outputs/artifacts/yoloe26s tests/assets/images/bus.jpg --label bus --mode both
+yoloe-benchmark outputs/artifacts/yoloe26s tests/assets/images/bus.jpg \
+  --label bus --mode both --runs 200 --warmup 20
 ```
+
+Jetson camera-path benchmarks use the same command and consume a finite live-source window of `warmup + runs` frames:
+
+```bash
+yoloe-benchmark outputs/artifacts/yoloe26s tests/assets/images/bus.jpg \
+  --label bus --mode camera --camera-source /dev/video0 \
+  --camera-zero-copy auto --runs 200 --warmup 20
+```
+
+Each result reports median/p95 latency, FPS, measured-loop process CPU, and measured-loop total system CPU. To compare
+against a saved baseline without failing the command, use:
+
+```bash
+yoloe-benchmark outputs/artifacts/yoloe26s tests/assets/images/bus.jpg \
+  --label bus --mode all --camera-source /dev/video0 \
+  --compare-to outputs/benchmarks/<baseline>.json
+```
+
+Add `--fail-on-regression` to make the command exit non-zero when the configured latency, FPS, or CPU thresholds are
+exceeded, or when the comparison is invalid because no modes or no metrics were compared.
 
 ## CI and release automation
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,6 +9,7 @@ nav:
   - Quickstart: quickstart.md
   - Export: export.md
   - Prompts: prompts.md
+  - Benchmarks: benchmarks.md
   - Camera GUI: camera-gui.md
   - Troubleshooting: troubleshooting.md
   - Development: development.md

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import subprocess
 import sys
 import weakref
@@ -9,7 +10,15 @@ from types import SimpleNamespace
 import numpy as np
 import pytest
 from yoloe_tensorrt import benchmark_cli
-from yoloe_tensorrt.benchmark_cli import _benchmark_runner, _format_ms
+from yoloe_tensorrt.benchmark_cli import (
+    _benchmark_runner,
+    _compare_benchmark_results,
+    _cpu_utilization,
+    _CpuSnapshot,
+    _default_output_name,
+    _format_ms,
+    _make_created_at,
+)
 from yoloe_tensorrt.source import SourceItem
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -65,11 +74,16 @@ def test_benchmark_cli_displays_help() -> None:
         cwd=REPO_ROOT,
     )
     assert result.returncode == 0
-    assert "Benchmark host-image and CUDA-tensor inference" in result.stdout
+    assert "Benchmark YOLOE TensorRT runtime paths" in result.stdout
     assert "--mode" in result.stdout
     assert "--visual-prompts" in result.stdout
     assert "--profile-allocations" in result.stdout
     assert "--track" in result.stdout
+    assert "--camera-source" in result.stdout
+    assert "--camera-zero-copy" in result.stdout
+    assert "--output-dir" in result.stdout
+    assert "--compare-to" in result.stdout
+    assert "invalid comparison" in result.stdout
 
 
 def test_benchmark_runner_profiles_allocations(capsys) -> None:
@@ -88,6 +102,71 @@ def test_benchmark_runner_profiles_allocations(capsys) -> None:
     output = capsys.readouterr().out
     assert "dummy: runs=1" in output
     assert "dummy Python retained allocations:" in output
+
+
+def test_benchmark_runner_reports_cpu_metrics(monkeypatch: pytest.MonkeyPatch, capsys) -> None:
+    snapshots = iter(
+        [
+            _CpuSnapshot(total_ticks=1000, idle_ticks=500, process_ticks=100, monotonic_s=1.0),
+            _CpuSnapshot(total_ticks=1100, idle_ticks=540, process_ticks=105, monotonic_s=1.5),
+        ]
+    )
+    monkeypatch.setattr(benchmark_cli, "_take_cpu_snapshot", lambda: next(snapshots))
+    monkeypatch.setattr(benchmark_cli, "_clock_ticks_per_second", lambda: 100)
+
+    result = _benchmark_runner(
+        "cpu",
+        lambda: SimpleNamespace(speed={}),
+        runs=1,
+        warmup=0,
+        profile_allocations=False,
+        allocation_top=0,
+    )
+
+    assert result["cpu"]["process_percent"]["mean"] == pytest.approx(10.0)
+    assert result["cpu"]["system_percent"]["mean"] == pytest.approx(60.0)
+    assert "cpu CPU: process_mean=10.0%" in capsys.readouterr().out
+
+
+def test_benchmark_runner_runs_setup_before_warmup_and_measured_iterations(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[str] = []
+    times = iter([1.0, 3.0])
+    monkeypatch.setattr(benchmark_cli.time, "perf_counter", lambda: next(times))
+    monkeypatch.setattr(benchmark_cli, "_take_cpu_snapshot", lambda: None)
+
+    def _setup() -> None:
+        calls.append("setup")
+
+    def _runner():
+        calls.append("runner")
+        return SimpleNamespace(speed={})
+
+    result = _benchmark_runner(
+        "setup",
+        _runner,
+        runs=1,
+        warmup=1,
+        profile_allocations=False,
+        allocation_top=0,
+        setup=_setup,
+    )
+
+    assert calls == ["setup", "runner", "setup", "runner"]
+    assert result["latency_ms"]["mean"] == pytest.approx(2000.0)
+
+
+def test_cpu_utilization_rejects_invalid_deltas(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(benchmark_cli, "_clock_ticks_per_second", lambda: 100)
+
+    assert (
+        _cpu_utilization(
+            _CpuSnapshot(total_ticks=100, idle_ticks=50, process_ticks=10, monotonic_s=1.0),
+            _CpuSnapshot(total_ticks=100, idle_ticks=50, process_ticks=11, monotonic_s=1.5),
+        )
+        is None
+    )
 
 
 def test_benchmark_runner_clears_final_result_before_allocation_snapshot(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -137,6 +216,143 @@ def test_benchmark_latency_summary_uses_nearest_rank_tail_percentiles() -> None:
     assert "p99=100.00ms" in summary
 
 
+def test_default_benchmark_output_name_preserves_subsecond_uniqueness() -> None:
+    created_at = _make_created_at()
+
+    assert "." in created_at
+    assert _default_output_name("2026-04-09T12:00:00.000001Z") != _default_output_name("2026-04-09T12:00:00.000002Z")
+
+
+def test_benchmark_main_writes_json_output(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    class _Engine:
+        native_visual_runtime = None
+
+        def clear_prompts(self) -> None:
+            pass
+
+        def set_classes(self, _labels: list[str]) -> None:
+            pass
+
+        def prepare_cuda_input(self, item: SourceItem, **_kwargs):
+            return item
+
+        def predict_item(self, *_args, **_kwargs):
+            return SimpleNamespace(speed={"preprocess": 1.0, "inference": 2.0, "postprocess": 3.0})
+
+        def predict(self, *_args, **_kwargs):
+            return [SimpleNamespace(speed={"preprocess": 0.0, "inference": 2.0, "postprocess": 3.0})]
+
+    image = np.zeros((4, 4, 3), dtype=np.uint8)
+    source_item = SourceItem(image=image, path="benchmark0")
+
+    monkeypatch.setattr(benchmark_cli, "_build_engine", lambda *_args, **_kwargs: _Engine())
+    monkeypatch.setattr(
+        "yoloe_tensorrt.source.normalize_source",
+        lambda *_args, **_kwargs: [source_item],
+    )
+
+    result = benchmark_cli.main(
+        [
+            str(tmp_path / "artifact"),
+            str(tmp_path / "image.jpg"),
+            "--mode",
+            "both",
+            "--runs",
+            "1",
+            "--warmup",
+            "0",
+            "--output-dir",
+            str(tmp_path / "benchmarks"),
+            "--output-name",
+            "result",
+            "--log-level",
+            "WARNING",
+        ]
+    )
+
+    payload = json.loads((tmp_path / "benchmarks" / "result.json").read_text())
+    assert result == 0
+    assert payload["schema_version"] == 1
+    assert payload["config"]["mode"] == "both"
+    assert set(payload["results"]) == {"host", "cuda"}
+    assert payload["results"]["host"]["latency_ms"]["count"] == 1
+
+
+def test_benchmark_all_mode_writes_host_cuda_and_camera_results(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    class _Engine:
+        native_visual_runtime = None
+
+        def __init__(self) -> None:
+            self.predict_item_paths: list[str] = []
+            self.prepared = False
+
+        def clear_prompts(self) -> None:
+            pass
+
+        def set_classes(self, _labels: list[str]) -> None:
+            pass
+
+        @property
+        def _main_fp16(self) -> bool:
+            return False
+
+        def prepare_cuda_input(self, item: SourceItem, **_kwargs):
+            self.prepared = True
+            return item
+
+        def predict_item(self, item: SourceItem, *_args, **_kwargs):
+            self.predict_item_paths.append(item.path)
+            return SimpleNamespace(speed={})
+
+        def predict(self, *_args, **_kwargs):
+            return [SimpleNamespace(speed={})]
+
+    image = np.zeros((4, 4, 3), dtype=np.uint8)
+    source_item = SourceItem(image=image, path="benchmark0")
+    camera_item = SourceItem(image=image, path="camera0")
+    engine = _Engine()
+    normalize_calls = {"count": 0}
+
+    def _normalize_source(*_args, **_kwargs):
+        normalize_calls["count"] += 1
+        return [source_item]
+
+    monkeypatch.setattr(benchmark_cli, "_build_engine", lambda *_args, **_kwargs: engine)
+    monkeypatch.setattr(benchmark_cli, "_camera_source_from_spec", lambda *_args, **_kwargs: [camera_item])
+    monkeypatch.setattr("yoloe_tensorrt.source.normalize_source", _normalize_source)
+
+    result = benchmark_cli.main(
+        [
+            str(tmp_path / "artifact"),
+            str(tmp_path / "image.jpg"),
+            "--mode",
+            "all",
+            "--camera-source",
+            "dummy://ball",
+            "--runs",
+            "1",
+            "--warmup",
+            "0",
+            "--output-dir",
+            str(tmp_path / "benchmarks"),
+            "--output-name",
+            "all-results",
+            "--log-level",
+            "WARNING",
+        ]
+    )
+
+    payload = json.loads((tmp_path / "benchmarks" / "all-results.json").read_text())
+    assert result == 0
+    assert set(payload["results"]) == {"host", "cuda", "camera"}
+    assert engine.prepared
+    assert engine.predict_item_paths == ["benchmark0", "camera0"]
+    assert normalize_calls["count"] == 1
+
+
 def test_benchmark_host_only_does_not_prepare_cuda_input(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     class _Engine:
         native_visual_runtime = None
@@ -172,9 +388,476 @@ def test_benchmark_host_only_does_not_prepare_cuda_input(monkeypatch: pytest.Mon
             "1",
             "--warmup",
             "0",
+            "--no-save",
             "--log-level",
             "WARNING",
         ]
     )
 
     assert result == 0
+
+
+def test_benchmark_camera_mode_requires_camera_source(tmp_path: Path) -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        benchmark_cli.main(
+            [
+                str(tmp_path / "artifact"),
+                str(tmp_path / "image.jpg"),
+                "--mode",
+                "camera",
+                "--runs",
+                "1",
+                "--warmup",
+                "0",
+                "--no-save",
+            ]
+        )
+
+    assert exc_info.value.code == 2
+
+
+def test_benchmark_camera_mode_uses_finite_source(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    class _Engine:
+        native_visual_runtime = None
+
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def clear_prompts(self) -> None:
+            pass
+
+        def set_classes(self, _labels: list[str]) -> None:
+            pass
+
+        @property
+        def _main_fp16(self) -> bool:
+            return True
+
+        def predict_item(self, *_args, **_kwargs):
+            self.calls += 1
+            return SimpleNamespace(speed={"preprocess": 1.0, "inference": 2.0, "postprocess": 3.0})
+
+    image = np.zeros((4, 4, 3), dtype=np.uint8)
+    engine = _Engine()
+    source_kwargs = {}
+
+    def _camera_source_from_spec(*_args, **kwargs):
+        source_kwargs.update(kwargs)
+        return [
+            SourceItem(image=image, path="camera0"),
+            SourceItem(image=image, path="camera1"),
+            SourceItem(image=image, path="camera2"),
+        ]
+
+    monkeypatch.setattr(benchmark_cli, "_build_engine", lambda *_args, **_kwargs: engine)
+    monkeypatch.setattr(benchmark_cli, "_camera_source_from_spec", _camera_source_from_spec)
+    monkeypatch.setattr(
+        "yoloe_tensorrt.source.normalize_source",
+        lambda *_args, **_kwargs: pytest.fail("camera-only benchmark should not decode the image argument"),
+    )
+
+    result = benchmark_cli.main(
+        [
+            str(tmp_path / "artifact"),
+            str(tmp_path / "image.jpg"),
+            "--mode",
+            "camera",
+            "--camera-source",
+            "dummy://ball",
+            "--camera-zero-copy",
+            "auto",
+            "--runs",
+            "1",
+            "--warmup",
+            "1",
+            "--no-save",
+            "--log-level",
+            "WARNING",
+        ]
+    )
+
+    assert result == 0
+    assert engine.calls == 2
+    assert source_kwargs["max_frames"] == 2
+    assert source_kwargs["target_imgsz"] == (640, 640)
+    assert source_kwargs["zero_copy"] is None
+    assert source_kwargs["fp16"] is True
+
+
+def test_benchmark_camera_mode_closes_source_on_early_exhaustion(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    class _Engine:
+        native_visual_runtime = None
+
+        def clear_prompts(self) -> None:
+            pass
+
+        def set_classes(self, _labels: list[str]) -> None:
+            pass
+
+        @property
+        def _main_fp16(self) -> bool:
+            return False
+
+        def predict_item(self, *_args, **_kwargs):
+            return SimpleNamespace(speed={})
+
+    class _CameraIterator:
+        def __init__(self) -> None:
+            self.closed = False
+            self.frames = iter([SourceItem(image=np.zeros((4, 4, 3), dtype=np.uint8), path="camera0")])
+
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            return next(self.frames)
+
+        def close(self) -> None:
+            self.closed = True
+
+    camera_source = _CameraIterator()
+
+    monkeypatch.setattr(benchmark_cli, "_build_engine", lambda *_args, **_kwargs: _Engine())
+    monkeypatch.setattr(benchmark_cli, "_camera_source_from_spec", lambda *_args, **_kwargs: camera_source)
+
+    with pytest.raises(RuntimeError, match="Camera benchmark source ended"):
+        benchmark_cli.main(
+            [
+                str(tmp_path / "artifact"),
+                str(tmp_path / "image.jpg"),
+                "--mode",
+                "camera",
+                "--camera-source",
+                "dummy://ball",
+                "--runs",
+                "2",
+                "--warmup",
+                "0",
+                "--no-save",
+                "--log-level",
+                "WARNING",
+            ]
+        )
+
+    assert camera_source.closed
+
+
+def test_benchmark_compare_detects_regressions() -> None:
+    baseline = {
+        "schema_version": 1,
+        "results": {
+            "host": {
+                "latency_ms": {"median": 10.0, "p95": 20.0},
+                "fps": 100.0,
+                "cpu": {
+                    "process_percent": {"mean": 20.0},
+                    "system_percent": {"mean": 30.0},
+                },
+            }
+        },
+    }
+    current = {
+        "schema_version": 1,
+        "results": {
+            "host": {
+                "latency_ms": {"median": 12.0, "p95": 25.0},
+                "fps": 80.0,
+                "cpu": {
+                    "process_percent": {"mean": 40.0},
+                    "system_percent": {"mean": 60.0},
+                },
+            }
+        },
+    }
+    thresholds = {
+        "median_latency_percent": 10.0,
+        "p95_latency_percent": 10.0,
+        "fps_percent": 10.0,
+        "process_cpu_percentage_points": 15.0,
+        "system_cpu_percentage_points": 15.0,
+    }
+
+    comparison = _compare_benchmark_results(current, baseline, thresholds)
+
+    assert comparison["status"] == "regressed"
+    assert comparison["regression_count"] == 5
+
+
+def test_benchmark_compare_reports_no_overlap() -> None:
+    thresholds = {
+        "median_latency_percent": 10.0,
+        "p95_latency_percent": 10.0,
+        "fps_percent": 10.0,
+        "process_cpu_percentage_points": 15.0,
+        "system_cpu_percentage_points": 15.0,
+    }
+
+    comparison = _compare_benchmark_results(
+        {"schema_version": 1, "results": {"host": {}}},
+        {"schema_version": 1, "results": {"cuda": {}}},
+        thresholds,
+    )
+
+    assert comparison["status"] == "no_overlap"
+    assert comparison["current_modes"] == ["host"]
+    assert comparison["baseline_modes"] == ["cuda"]
+
+
+def test_benchmark_compare_reports_no_comparable_metrics() -> None:
+    thresholds = {
+        "median_latency_percent": 10.0,
+        "p95_latency_percent": 10.0,
+        "fps_percent": 10.0,
+        "process_cpu_percentage_points": 15.0,
+        "system_cpu_percentage_points": 15.0,
+    }
+
+    comparison = _compare_benchmark_results(
+        {"schema_version": 1, "results": {"host": {}}},
+        {"schema_version": 1, "results": {"host": {}}},
+        thresholds,
+    )
+
+    assert comparison["status"] == "no_comparable_metrics"
+    assert comparison["unchecked_modes"] == ["host"]
+
+
+def test_benchmark_compare_only_fails_when_requested(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    class _Engine:
+        native_visual_runtime = None
+
+        def clear_prompts(self) -> None:
+            pass
+
+        def set_classes(self, _labels: list[str]) -> None:
+            pass
+
+        def predict_item(self, *_args, **_kwargs):
+            return SimpleNamespace(speed={})
+
+    baseline_path = tmp_path / "baseline.json"
+    baseline_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "results": {
+                    "host": {
+                        "latency_ms": {"median": 10.0, "p95": 10.0},
+                        "fps": 100.0,
+                        "cpu": {
+                            "process_percent": {"mean": 10.0},
+                            "system_percent": {"mean": 10.0},
+                        },
+                    }
+                },
+            }
+        )
+    )
+    current_result = {
+        "runs": 1,
+        "warmup": 0,
+        "latency_ms": {"median": 20.0, "p95": 20.0},
+        "fps": 50.0,
+        "speed_ms": {},
+        "cpu": {
+            "process_percent": {"mean": 40.0},
+            "system_percent": {"mean": 40.0},
+        },
+        "allocations": None,
+    }
+    image = np.zeros((4, 4, 3), dtype=np.uint8)
+
+    monkeypatch.setattr(benchmark_cli, "_build_engine", lambda *_args, **_kwargs: _Engine())
+    monkeypatch.setattr(benchmark_cli, "_benchmark_runner", lambda *_args, **_kwargs: current_result)
+    monkeypatch.setattr(
+        "yoloe_tensorrt.source.normalize_source",
+        lambda *_args, **_kwargs: [SourceItem(image=image, path="benchmark0")],
+    )
+
+    base_args = [
+        str(tmp_path / "artifact"),
+        str(tmp_path / "image.jpg"),
+        "--mode",
+        "host",
+        "--runs",
+        "1",
+        "--warmup",
+        "0",
+        "--compare-to",
+        str(baseline_path),
+        "--no-save",
+        "--log-level",
+        "WARNING",
+    ]
+
+    assert benchmark_cli.main(base_args) == 0
+    assert benchmark_cli.main([*base_args, "--fail-on-regression"]) == 1
+
+
+def test_benchmark_compare_no_metrics_fails_regression_gate(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    class _Engine:
+        native_visual_runtime = None
+
+        def clear_prompts(self) -> None:
+            pass
+
+        def set_classes(self, _labels: list[str]) -> None:
+            pass
+
+        def predict_item(self, *_args, **_kwargs):
+            return SimpleNamespace(speed={})
+
+    baseline_path = tmp_path / "baseline.json"
+    baseline_path.write_text(json.dumps({"schema_version": 1, "results": {"host": {}}}))
+    image = np.zeros((4, 4, 3), dtype=np.uint8)
+
+    monkeypatch.setattr(benchmark_cli, "_build_engine", lambda *_args, **_kwargs: _Engine())
+    monkeypatch.setattr(
+        benchmark_cli,
+        "_benchmark_runner",
+        lambda *_args, **_kwargs: {
+            "runs": 1,
+            "warmup": 0,
+            "latency_ms": {"median": 10.0, "p95": 10.0},
+            "fps": 100.0,
+            "speed_ms": {},
+            "cpu": {
+                "process_percent": {"mean": 10.0},
+                "system_percent": {"mean": 10.0},
+            },
+            "allocations": None,
+        },
+    )
+    monkeypatch.setattr(
+        "yoloe_tensorrt.source.normalize_source",
+        lambda *_args, **_kwargs: [SourceItem(image=image, path="benchmark0")],
+    )
+    base_args = [
+        str(tmp_path / "artifact"),
+        str(tmp_path / "image.jpg"),
+        "--mode",
+        "host",
+        "--runs",
+        "1",
+        "--warmup",
+        "0",
+        "--compare-to",
+        str(baseline_path),
+        "--no-save",
+        "--log-level",
+        "WARNING",
+    ]
+
+    assert benchmark_cli.main(base_args) == 0
+    assert benchmark_cli.main([*base_args, "--fail-on-regression"]) == 1
+
+
+def test_benchmark_compare_no_overlap_fails_regression_gate(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    class _Engine:
+        native_visual_runtime = None
+
+        def clear_prompts(self) -> None:
+            pass
+
+        def set_classes(self, _labels: list[str]) -> None:
+            pass
+
+        def predict_item(self, *_args, **_kwargs):
+            return SimpleNamespace(speed={})
+
+    baseline_path = tmp_path / "baseline.json"
+    baseline_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "results": {
+                    "cuda": {
+                        "latency_ms": {"median": 10.0, "p95": 10.0},
+                        "fps": 100.0,
+                        "cpu": {
+                            "process_percent": {"mean": 10.0},
+                            "system_percent": {"mean": 10.0},
+                        },
+                    }
+                },
+            }
+        )
+    )
+    image = np.zeros((4, 4, 3), dtype=np.uint8)
+
+    monkeypatch.setattr(benchmark_cli, "_build_engine", lambda *_args, **_kwargs: _Engine())
+    monkeypatch.setattr(
+        benchmark_cli,
+        "_benchmark_runner",
+        lambda *_args, **_kwargs: {
+            "runs": 1,
+            "warmup": 0,
+            "latency_ms": {"median": 10.0, "p95": 10.0},
+            "fps": 100.0,
+            "speed_ms": {},
+            "cpu": {
+                "process_percent": {"mean": 10.0},
+                "system_percent": {"mean": 10.0},
+            },
+            "allocations": None,
+        },
+    )
+    monkeypatch.setattr(
+        "yoloe_tensorrt.source.normalize_source",
+        lambda *_args, **_kwargs: [SourceItem(image=image, path="benchmark0")],
+    )
+    base_args = [
+        str(tmp_path / "artifact"),
+        str(tmp_path / "image.jpg"),
+        "--mode",
+        "host",
+        "--runs",
+        "1",
+        "--warmup",
+        "0",
+        "--compare-to",
+        str(baseline_path),
+        "--no-save",
+        "--log-level",
+        "WARNING",
+    ]
+
+    assert benchmark_cli.main(base_args) == 0
+    assert benchmark_cli.main([*base_args, "--fail-on-regression"]) == 1
+
+
+def test_benchmark_compare_rejects_malformed_baseline_before_building_engine(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    baseline_path = tmp_path / "baseline.json"
+    baseline_path.write_text(json.dumps({"results": {}}))
+    monkeypatch.setattr(
+        benchmark_cli,
+        "_build_engine",
+        lambda *_args, **_kwargs: pytest.fail("malformed baseline should fail before engine build"),
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        benchmark_cli.main(
+            [
+                str(tmp_path / "artifact"),
+                str(tmp_path / "image.jpg"),
+                "--mode",
+                "host",
+                "--compare-to",
+                str(baseline_path),
+                "--no-save",
+            ]
+        )
+
+    assert exc_info.value.code == 2

--- a/yoloe_tensorrt/__main__.py
+++ b/yoloe_tensorrt/__main__.py
@@ -19,7 +19,7 @@ def build_arg_parser() -> argparse.ArgumentParser:
     export_parser = subparsers.add_parser("export", help="Export a YOLOE checkpoint into an artifact bundle.")
     export_parser.set_defaults(handler="export")
 
-    benchmark_parser = subparsers.add_parser("benchmark", help="Benchmark host-image and CUDA-tensor inference.")
+    benchmark_parser = subparsers.add_parser("benchmark", help="Benchmark runtime performance.")
     benchmark_parser.set_defaults(handler="benchmark")
     return parser
 

--- a/yoloe_tensorrt/benchmark_cli.py
+++ b/yoloe_tensorrt/benchmark_cli.py
@@ -2,25 +2,31 @@ from __future__ import annotations
 
 import argparse
 import gc
+import json
 import logging
 import math
+import os
+import platform
 import statistics
+import sys
 import time
 import tracemalloc
 from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
-from typing import Callable
+from typing import Any, Callable
 
 import numpy as np
 
+from ._version import __version__
 from .logging_utils import configure_logging
 
 
 def build_arg_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description=(
-            "Benchmark host-image and CUDA-tensor inference paths for a YOLOE TensorRT artifact bundle, "
-            "and optionally benchmark visual-prompt updates."
+            "Benchmark YOLOE TensorRT runtime paths, camera ingest, visual-prompt updates, and JSON regression output."
         )
     )
     parser.add_argument("artifact_dir", help="Artifact bundle directory to benchmark.")
@@ -37,9 +43,9 @@ def build_arg_parser() -> argparse.ArgumentParser:
     parser.add_argument("--warmup", type=int, default=5, help="Warmup iterations per mode. Defaults to 5.")
     parser.add_argument(
         "--mode",
-        choices=("host", "cuda", "both"),
+        choices=("host", "cuda", "camera", "both", "all"),
         default="both",
-        help="Benchmark the host-image path, CUDA fast path, or both.",
+        help="Benchmark the host-image path, CUDA fast path, camera path, host+CUDA, or all paths.",
     )
     parser.add_argument("--conf", type=float, default=0.25, help="Detection confidence threshold.")
     parser.add_argument("--device", default="cuda:0", help="Torch/TensorRT device. Defaults to cuda:0.")
@@ -59,6 +65,58 @@ def build_arg_parser() -> argparse.ArgumentParser:
         default=5,
         help="Number of allocation hot spots to print when --profile-allocations is enabled.",
     )
+    parser.add_argument("--output-dir", default="outputs/benchmarks", help="Directory for JSON benchmark output.")
+    parser.add_argument("--output-name", default=None, help="Output JSON filename. Defaults to a timestamped name.")
+    parser.add_argument("--no-save", action="store_true", help="Do not write a JSON benchmark result file.")
+    parser.add_argument(
+        "--compare-to", type=Path, default=None, help="Compare current results to a prior JSON benchmark."
+    )
+    parser.add_argument(
+        "--fail-on-regression",
+        action="store_true",
+        help="Exit non-zero when --compare-to detects a regression or invalid comparison.",
+    )
+    parser.add_argument(
+        "--max-p95-latency-regression",
+        type=float,
+        default=10.0,
+        help="Maximum allowed p95 latency regression percentage for --compare-to.",
+    )
+    parser.add_argument(
+        "--max-median-latency-regression",
+        type=float,
+        default=10.0,
+        help="Maximum allowed median latency regression percentage for --compare-to.",
+    )
+    parser.add_argument(
+        "--max-process-cpu-regression",
+        type=float,
+        default=15.0,
+        help="Maximum allowed process CPU regression in percentage points for --compare-to.",
+    )
+    parser.add_argument(
+        "--max-system-cpu-regression",
+        type=float,
+        default=15.0,
+        help="Maximum allowed system CPU regression in percentage points for --compare-to.",
+    )
+    parser.add_argument(
+        "--max-fps-regression",
+        type=float,
+        default=10.0,
+        help="Maximum allowed FPS regression percentage for --compare-to.",
+    )
+    parser.add_argument("--camera-source", default=None, help="Camera source for --mode camera or --mode all.")
+    parser.add_argument("--camera-width", type=int, default=None, help="Requested camera width.")
+    parser.add_argument("--camera-height", type=int, default=None, help="Requested camera height.")
+    parser.add_argument("--camera-fps", type=int, default=None, help="Requested camera frame rate.")
+    parser.add_argument("--camera-timeout", type=float, default=5.0, help="Camera frame timeout in seconds.")
+    parser.add_argument(
+        "--camera-zero-copy",
+        choices=("auto", "required", "off"),
+        default="auto",
+        help="Camera zero-copy policy for Jetson sources.",
+    )
     parser.add_argument(
         "--visual-prompts",
         choices=("none", "bbox", "mask", "both"),
@@ -73,6 +131,18 @@ def build_arg_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--log-level", default="INFO", help="Logging level for the benchmark command.")
     return parser
+
+
+@dataclass(frozen=True)
+class _CpuSnapshot:
+    total_ticks: int
+    idle_ticks: int
+    process_ticks: int
+    monotonic_s: float
+
+
+_PROC_STAT_PATH = Path("/proc/stat")
+_PROC_SELF_STAT_PATH = Path("/proc/self/stat")
 
 
 def _format_ms(values: list[float]) -> str:
@@ -94,6 +164,31 @@ def _nearest_rank_percentile(sorted_values: list[float], percentile: float) -> f
     return sorted_values[index]
 
 
+def _stats(values: list[float]) -> dict[str, float | int | None]:
+    if not values:
+        return {
+            "count": 0,
+            "mean": None,
+            "median": None,
+            "p95": None,
+            "p99": None,
+            "stdev": None,
+            "min": None,
+            "max": None,
+        }
+    sorted_values = sorted(values)
+    return {
+        "count": len(values),
+        "mean": statistics.fmean(values),
+        "median": statistics.median(values),
+        "p95": _nearest_rank_percentile(sorted_values, 0.95),
+        "p99": _nearest_rank_percentile(sorted_values, 0.99),
+        "stdev": statistics.pstdev(values) if len(values) > 1 else 0.0,
+        "min": sorted_values[0],
+        "max": sorted_values[-1],
+    }
+
+
 def _summarize_result_speeds(
     name: str,
     preprocess: list[float],
@@ -105,6 +200,24 @@ def _summarize_result_speeds(
     print(
         f"{name} speed breakdown: preprocess={statistics.fmean(preprocess):.2f}ms "
         f"inference={statistics.fmean(inference):.2f}ms postprocess={statistics.fmean(postprocess):.2f}ms"
+    )
+
+
+def _print_cpu_summary(name: str, process_cpu: list[float], system_cpu: list[float]) -> None:
+    if not process_cpu or not system_cpu:
+        print(f"{name} CPU: unavailable")
+        return
+    process_stats = _stats(process_cpu)
+    system_stats = _stats(system_cpu)
+    print(
+        f"{name} CPU: process_mean={float(process_stats['mean']):.1f}% "
+        f"process_median={float(process_stats['median']):.1f}% "
+        f"process_p95={float(process_stats['p95']):.1f}% "
+        f"process_max={float(process_stats['max']):.1f}% "
+        f"system_mean={float(system_stats['mean']):.1f}% "
+        f"system_median={float(system_stats['median']):.1f}% "
+        f"system_p95={float(system_stats['p95']):.1f}% "
+        f"system_max={float(system_stats['max']):.1f}%"
     )
 
 
@@ -122,7 +235,7 @@ def _print_allocation_summary(
     after: tracemalloc.Snapshot,
     peak_bytes: int,
     top_n: int,
-) -> None:
+) -> dict[str, Any]:
     stats = [stat for stat in after.compare_to(before, "lineno") if stat.size_diff > 0 or stat.count_diff > 0]
     retained_bytes = sum(max(0, stat.size_diff) for stat in stats)
     retained_count = sum(max(0, stat.count_diff) for stat in stats)
@@ -130,12 +243,80 @@ def _print_allocation_summary(
         f"{name} Python retained allocations: retained={_format_bytes(retained_bytes)} "
         f"count={retained_count} peak_traced={_format_bytes(peak_bytes)}"
     )
+    hotspots = []
     for index, stat in enumerate(stats[: max(0, int(top_n))], start=1):
         frame = stat.traceback[0]
+        hotspot = {
+            "filename": frame.filename,
+            "line": int(frame.lineno),
+            "retained_bytes": max(0, int(stat.size_diff)),
+            "retained_count": max(0, int(stat.count_diff)),
+        }
+        hotspots.append(hotspot)
         print(
             f"{name} retained allocation hotspot {index}: {frame.filename}:{frame.lineno} "
             f"size={_format_bytes(max(0, stat.size_diff))} count={max(0, stat.count_diff)}"
         )
+    return {
+        "retained_bytes": int(retained_bytes),
+        "retained_count": int(retained_count),
+        "peak_traced_bytes": int(peak_bytes),
+        "hotspots": hotspots,
+    }
+
+
+def _read_system_cpu_ticks(path: Path = _PROC_STAT_PATH) -> tuple[int, int]:
+    first_line = path.read_text().splitlines()[0]
+    parts = first_line.split()
+    if not parts or parts[0] != "cpu":
+        raise ValueError(f"Unable to parse system CPU stats from {path}")
+    ticks = [int(value) for value in parts[1:]]
+    total_ticks = sum(ticks)
+    idle_ticks = ticks[3] + (ticks[4] if len(ticks) > 4 else 0)
+    return total_ticks, idle_ticks
+
+
+def _read_process_cpu_ticks(path: Path = _PROC_SELF_STAT_PATH) -> int:
+    text = path.read_text()
+    suffix = text[text.rfind(")") + 2 :].split()
+    if len(suffix) < 13:
+        raise ValueError(f"Unable to parse process CPU stats from {path}")
+    return int(suffix[11]) + int(suffix[12])
+
+
+def _clock_ticks_per_second() -> int:
+    try:
+        return int(os.sysconf("SC_CLK_TCK"))
+    except (AttributeError, OSError, ValueError):
+        return 100
+
+
+def _take_cpu_snapshot() -> _CpuSnapshot | None:
+    try:
+        total_ticks, idle_ticks = _read_system_cpu_ticks()
+        process_ticks = _read_process_cpu_ticks()
+    except (OSError, ValueError, IndexError):
+        return None
+    return _CpuSnapshot(
+        total_ticks=total_ticks,
+        idle_ticks=idle_ticks,
+        process_ticks=process_ticks,
+        monotonic_s=time.perf_counter(),
+    )
+
+
+def _cpu_utilization(before: _CpuSnapshot | None, after: _CpuSnapshot | None) -> tuple[float, float] | None:
+    if before is None or after is None:
+        return None
+    elapsed_s = after.monotonic_s - before.monotonic_s
+    total_delta = after.total_ticks - before.total_ticks
+    idle_delta = after.idle_ticks - before.idle_ticks
+    process_delta = after.process_ticks - before.process_ticks
+    if elapsed_s <= 0.0 or total_delta <= 0 or process_delta < 0:
+        return None
+    process_cpu = (process_delta / _clock_ticks_per_second()) / elapsed_s * 100.0
+    system_cpu = max(0.0, min(100.0, (total_delta - idle_delta) / total_delta * 100.0))
+    return process_cpu, system_cpu
 
 
 def _benchmark_runner(
@@ -146,16 +327,22 @@ def _benchmark_runner(
     warmup: int,
     profile_allocations: bool,
     allocation_top: int,
-) -> None:
+    setup: Callable[[], None] | None = None,
+) -> dict[str, Any]:
     for _ in range(warmup):
+        if setup is not None:
+            setup()
         runner()
 
     latencies_ms = [0.0] * runs
     preprocess = [0.0] * runs
     inference = [0.0] * runs
     postprocess = [0.0] * runs
+    cpu_before = None
+    cpu_after = None
 
     before_snapshot = None
+    after_snapshot = None
     peak_bytes = 0
     gc_was_enabled = gc.isenabled()
     if profile_allocations:
@@ -167,7 +354,10 @@ def _benchmark_runner(
     result = None
     speed = None
     try:
+        cpu_before = _take_cpu_snapshot()
         for index in range(runs):
+            if setup is not None:
+                setup()
             start = time.perf_counter()
             result = runner()
             latencies_ms[index] = (time.perf_counter() - start) * 1000.0
@@ -175,6 +365,7 @@ def _benchmark_runner(
             preprocess[index] = float(speed.get("preprocess") or 0.0)
             inference[index] = float(speed.get("inference") or 0.0)
             postprocess[index] = float(speed.get("postprocess") or 0.0)
+        cpu_after = _take_cpu_snapshot()
     finally:
         result = None
         speed = None
@@ -187,12 +378,348 @@ def _benchmark_runner(
             else:
                 gc.disable()
 
+    cpu_values = _cpu_utilization(cpu_before, cpu_after)
+    process_cpu = [cpu_values[0]] if cpu_values is not None else []
+    system_cpu = [cpu_values[1]] if cpu_values is not None else []
     fps = 1000.0 / statistics.fmean(latencies_ms)
     print(f"{name}: runs={runs} {_format_ms(latencies_ms)} fps={fps:.2f}")
     _summarize_result_speeds(name, preprocess, inference, postprocess)
+    _print_cpu_summary(name, process_cpu, system_cpu)
+    allocation_summary = None
     if profile_allocations:
         assert before_snapshot is not None
-        _print_allocation_summary(name, before_snapshot, after_snapshot, peak_bytes, allocation_top)
+        assert after_snapshot is not None
+        allocation_summary = _print_allocation_summary(
+            name, before_snapshot, after_snapshot, peak_bytes, allocation_top
+        )
+
+    return {
+        "runs": int(runs),
+        "warmup": int(warmup),
+        "latency_ms": _stats(latencies_ms),
+        "fps": float(fps),
+        "speed_ms": {
+            "preprocess": _stats(preprocess),
+            "inference": _stats(inference),
+            "postprocess": _stats(postprocess),
+        },
+        "cpu": {
+            "process_percent": _stats(process_cpu),
+            "system_percent": _stats(system_cpu),
+        },
+        "allocations": allocation_summary,
+    }
+
+
+def _selected_modes(mode: str) -> list[str]:
+    if mode == "both":
+        return ["host", "cuda"]
+    if mode == "all":
+        return ["host", "cuda", "camera"]
+    return [mode]
+
+
+def _camera_zero_copy_value(policy: str) -> bool | None:
+    if policy == "required":
+        return True
+    if policy == "off":
+        return False
+    return None
+
+
+def _make_created_at() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="microseconds").replace("+00:00", "Z")
+
+
+def _default_output_name(created_at: str) -> str:
+    stamp = created_at.replace("-", "").replace(":", "")
+    return f"benchmark-{stamp}.json"
+
+
+def _resolve_output_path(output_dir: str | Path, output_name: str | None, created_at: str) -> Path:
+    filename = output_name or _default_output_name(created_at)
+    path = Path(filename)
+    if path.suffix != ".json":
+        path = path.with_suffix(".json")
+    if path.is_absolute():
+        return path
+    return Path(output_dir) / path
+
+
+def _benchmark_metadata(args: argparse.Namespace, created_at: str) -> dict[str, Any]:
+    return {
+        "schema_version": 1,
+        "created_at": created_at,
+        "package_version": __version__,
+        "platform": {
+            "system": platform.system(),
+            "release": platform.release(),
+            "machine": platform.machine(),
+            "python": sys.version.split()[0],
+        },
+        "config": {
+            "artifact_dir": str(Path(args.artifact_dir)),
+            "image": str(Path(args.image)),
+            "labels": list(args.labels or ["bus"]),
+            "imgsz": int(args.imgsz),
+            "runs": int(args.runs),
+            "warmup": int(args.warmup),
+            "mode": str(args.mode),
+            "track": bool(args.track),
+            "conf": float(args.conf),
+            "device": str(args.device),
+            "camera": {
+                "source": args.camera_source,
+                "width": args.camera_width,
+                "height": args.camera_height,
+                "fps": args.camera_fps,
+                "timeout_s": float(args.camera_timeout),
+                "zero_copy": str(args.camera_zero_copy),
+            },
+        },
+    }
+
+
+def _write_benchmark_json(document: dict[str, Any], output_dir: str | Path, output_name: str | None) -> Path:
+    output_path = _resolve_output_path(output_dir, output_name, str(document["created_at"]))
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(document, indent=2, sort_keys=True) + "\n")
+    return output_path
+
+
+def _load_benchmark_baseline(path: Path) -> dict[str, Any]:
+    try:
+        document = json.loads(path.read_text())
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Invalid benchmark baseline JSON '{path}': {exc.msg}") from exc
+    except OSError as exc:
+        raise ValueError(f"Unable to read benchmark baseline '{path}': {exc}") from exc
+    _validate_benchmark_document(document, path)
+    return document
+
+
+def _validate_benchmark_document(document: object, path: Path) -> None:
+    if not isinstance(document, dict):
+        raise ValueError(f"Benchmark baseline '{path}' must be a JSON object")
+    if document.get("schema_version") != 1:
+        raise ValueError(f"Benchmark baseline '{path}' must have schema_version=1")
+    results = document.get("results")
+    if not isinstance(results, dict) or not results:
+        raise ValueError(f"Benchmark baseline '{path}' must contain a non-empty results object")
+    for mode, result in results.items():
+        if not isinstance(mode, str) or not isinstance(result, dict):
+            raise ValueError(f"Benchmark baseline '{path}' has an invalid result entry")
+
+
+def _close_if_available(value: object) -> None:
+    close = getattr(value, "close", None)
+    if callable(close):
+        close()
+
+
+def _nested_float(data: dict[str, Any], path: tuple[str, ...]) -> float | None:
+    value: Any = data
+    for key in path:
+        if not isinstance(value, dict) or key not in value:
+            return None
+        value = value[key]
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _latency_regression(
+    name: str,
+    current: dict[str, Any],
+    baseline: dict[str, Any],
+    path: tuple[str, ...],
+    max_percent: float,
+) -> dict[str, Any] | None:
+    current_value = _nested_float(current, path)
+    baseline_value = _nested_float(baseline, path)
+    if current_value is None or baseline_value is None or baseline_value <= 0.0:
+        return None
+    delta_percent = (current_value - baseline_value) / baseline_value * 100.0
+    return {
+        "metric": name,
+        "baseline": baseline_value,
+        "current": current_value,
+        "delta": delta_percent,
+        "unit": "percent",
+        "threshold": float(max_percent),
+        "regressed": delta_percent > max_percent,
+    }
+
+
+def _fps_regression(current: dict[str, Any], baseline: dict[str, Any], max_percent: float) -> dict[str, Any] | None:
+    current_value = _nested_float(current, ("fps",))
+    baseline_value = _nested_float(baseline, ("fps",))
+    if current_value is None or baseline_value is None or baseline_value <= 0.0:
+        return None
+    delta_percent = (baseline_value - current_value) / baseline_value * 100.0
+    return {
+        "metric": "fps",
+        "baseline": baseline_value,
+        "current": current_value,
+        "delta": delta_percent,
+        "unit": "percent",
+        "threshold": float(max_percent),
+        "regressed": delta_percent > max_percent,
+    }
+
+
+def _cpu_regression(
+    name: str,
+    current: dict[str, Any],
+    baseline: dict[str, Any],
+    path: tuple[str, ...],
+    max_percentage_points: float,
+) -> dict[str, Any] | None:
+    current_value = _nested_float(current, path)
+    baseline_value = _nested_float(baseline, path)
+    if current_value is None or baseline_value is None:
+        return None
+    delta_points = current_value - baseline_value
+    return {
+        "metric": name,
+        "baseline": baseline_value,
+        "current": current_value,
+        "delta": delta_points,
+        "unit": "percentage_points",
+        "threshold": float(max_percentage_points),
+        "regressed": delta_points > max_percentage_points,
+    }
+
+
+def _compare_benchmark_results(
+    current: dict[str, Any],
+    baseline: dict[str, Any],
+    thresholds: dict[str, float],
+) -> dict[str, Any]:
+    current_results = current.get("results", {})
+    baseline_results = baseline.get("results", {})
+    if not isinstance(current_results, dict):
+        current_results = {}
+    if not isinstance(baseline_results, dict):
+        baseline_results = {}
+    current_mode_names = sorted(str(mode) for mode in current_results)
+    baseline_mode_names = sorted(str(mode) for mode in baseline_results)
+    overlapping_modes = sorted(set(current_results) & set(baseline_results))
+    modes: dict[str, Any] = {}
+    regression_count = 0
+    unchecked_modes: list[str] = []
+    if not overlapping_modes:
+        return {
+            "status": "no_overlap",
+            "regression_count": 0,
+            "modes": modes,
+            "current_modes": current_mode_names,
+            "baseline_modes": baseline_mode_names,
+            "unchecked_modes": unchecked_modes,
+        }
+    for mode in overlapping_modes:
+        current_mode = current_results[mode]
+        baseline_mode = baseline_results[mode]
+        checks = [
+            _latency_regression(
+                "latency_ms.median",
+                current_mode,
+                baseline_mode,
+                ("latency_ms", "median"),
+                thresholds["median_latency_percent"],
+            ),
+            _latency_regression(
+                "latency_ms.p95",
+                current_mode,
+                baseline_mode,
+                ("latency_ms", "p95"),
+                thresholds["p95_latency_percent"],
+            ),
+            _fps_regression(current_mode, baseline_mode, thresholds["fps_percent"]),
+            _cpu_regression(
+                "cpu.process_percent.mean",
+                current_mode,
+                baseline_mode,
+                ("cpu", "process_percent", "mean"),
+                thresholds["process_cpu_percentage_points"],
+            ),
+            _cpu_regression(
+                "cpu.system_percent.mean",
+                current_mode,
+                baseline_mode,
+                ("cpu", "system_percent", "mean"),
+                thresholds["system_cpu_percentage_points"],
+            ),
+        ]
+        resolved_checks = [check for check in checks if check is not None]
+        if not resolved_checks:
+            unchecked_modes.append(str(mode))
+            modes[mode] = {
+                "status": "no_comparable_metrics",
+                "checks": [],
+            }
+            continue
+        mode_regressions = [check for check in resolved_checks if check["regressed"]]
+        regression_count += len(mode_regressions)
+        modes[mode] = {
+            "status": "regressed" if mode_regressions else "ok",
+            "checks": resolved_checks,
+        }
+    if regression_count:
+        status = "regressed"
+    elif unchecked_modes:
+        status = "no_comparable_metrics"
+    else:
+        status = "ok"
+    return {
+        "status": status,
+        "regression_count": regression_count,
+        "modes": modes,
+        "current_modes": current_mode_names,
+        "baseline_modes": baseline_mode_names,
+        "unchecked_modes": unchecked_modes,
+    }
+
+
+def _comparison_thresholds(args: argparse.Namespace) -> dict[str, float]:
+    return {
+        "p95_latency_percent": float(args.max_p95_latency_regression),
+        "median_latency_percent": float(args.max_median_latency_regression),
+        "process_cpu_percentage_points": float(args.max_process_cpu_regression),
+        "system_cpu_percentage_points": float(args.max_system_cpu_regression),
+        "fps_percent": float(args.max_fps_regression),
+    }
+
+
+def _print_comparison_summary(comparison: dict[str, Any], baseline_path: Path) -> None:
+    if comparison["status"] == "no_overlap":
+        current_modes = ", ".join(comparison.get("current_modes") or ["<none>"])
+        baseline_modes = ", ".join(comparison.get("baseline_modes") or ["<none>"])
+        print(
+            f"comparison: no overlapping modes with baseline '{baseline_path}' "
+            f"(current={current_modes}; baseline={baseline_modes})"
+        )
+        return
+    if comparison.get("unchecked_modes"):
+        unchecked_modes = ", ".join(comparison["unchecked_modes"])
+        print(f"comparison: no comparable metrics for mode(s) {unchecked_modes} in baseline '{baseline_path}'")
+        if comparison["status"] == "no_comparable_metrics":
+            return
+    if comparison["status"] == "ok":
+        print(f"comparison: no regressions detected against '{baseline_path}'")
+        return
+    print(f"comparison: {comparison['regression_count']} regression(s) detected against '{baseline_path}'")
+    for mode, mode_comparison in comparison["modes"].items():
+        for check in mode_comparison["checks"]:
+            if check["regressed"]:
+                print(
+                    f"comparison regression {mode} {check['metric']}: current={check['current']:.3f} "
+                    f"baseline={check['baseline']:.3f} delta={check['delta']:.2f}{check['unit']} "
+                    f"threshold={check['threshold']:.2f}"
+                )
 
 
 def _build_engine(artifact_dir: Path, device: str, *, disable_native_visual: bool = False):
@@ -208,6 +735,12 @@ def _build_engine(artifact_dir: Path, device: str, *, disable_native_visual: boo
         return YOLOEEngine.from_engine(artifact_dir, device=device)
     finally:
         engine_module.build_native_visual_runtime = original_builder
+
+
+def _camera_source_from_spec(source_value: str, **kwargs):
+    from .gstreamer import camera_source_from_spec
+
+    return camera_source_from_spec(source_value, **kwargs)
 
 
 def _build_visual_prompt_inputs(image: np.ndarray, label: str) -> dict[str, dict[str, object]]:
@@ -251,6 +784,24 @@ def _synchronize_engine_device(engine: object) -> None:
 def main(argv: list[str] | None = None) -> int:
     parser = build_arg_parser()
     args = parser.parse_args(argv)
+    runs = int(args.runs)
+    warmup = int(args.warmup)
+    selected_modes = _selected_modes(str(args.mode))
+    if runs <= 0:
+        parser.error("--runs must be greater than 0")
+    if warmup < 0:
+        parser.error("--warmup must be greater than or equal to 0")
+    if "camera" in selected_modes and not args.camera_source:
+        parser.error("--camera-source is required when --mode is 'camera' or 'all'")
+    if args.compare_to is not None and not Path(args.compare_to).is_file():
+        parser.error(f"--compare-to file does not exist: {args.compare_to}")
+    baseline = None
+    if args.compare_to is not None:
+        try:
+            baseline = _load_benchmark_baseline(Path(args.compare_to))
+        except ValueError as exc:
+            parser.error(str(exc))
+
     configure_logging(level=args.log_level, include_timestamps=True)
 
     from .preprocess import normalize_imgsz
@@ -258,32 +809,44 @@ def main(argv: list[str] | None = None) -> int:
 
     labels = list(args.labels or ["bus"])
     target_size = normalize_imgsz(int(args.imgsz))
+    created_at = _make_created_at()
+    document = _benchmark_metadata(args, created_at)
+    document["results"] = {}
 
     artifact_dir = Path(args.artifact_dir)
     engine = _build_engine(artifact_dir, args.device)
     engine.clear_prompts()
     engine.set_classes(labels)
 
-    item = normalize_source(Path(args.image), default_prefix="benchmark")[0]
-    host_tracker = engine.create_tracker() if args.track and args.mode in {"host", "both"} else None
+    item = None
+
+    def _benchmark_item():
+        nonlocal item
+        if item is None:
+            item = normalize_source(Path(args.image), default_prefix="benchmark")[0]
+        return item
+
+    host_tracker = engine.create_tracker() if args.track and "host" in selected_modes else None
 
     def _run_host():
+        item = _benchmark_item()
         if host_tracker is not None:
             return host_tracker.update(item, source_key="benchmark", imgsz=target_size, conf=float(args.conf))
         return engine.predict_item(item, imgsz=target_size, conf=float(args.conf))
 
-    if args.mode in {"host", "both"}:
-        _benchmark_runner(
-            "host-track" if args.track else "host",
+    if "host" in selected_modes:
+        name = "host-track" if args.track else "host"
+        document["results"][name] = _benchmark_runner(
+            name,
             _run_host,
-            runs=int(args.runs),
-            warmup=int(args.warmup),
+            runs=runs,
+            warmup=warmup,
             profile_allocations=bool(args.profile_allocations),
             allocation_top=int(args.allocation_top),
         )
 
-    if args.mode in {"cuda", "both"}:
-        prepared_input = engine.prepare_cuda_input(item, imgsz=target_size)
+    if "cuda" in selected_modes:
+        prepared_input = engine.prepare_cuda_input(_benchmark_item(), imgsz=target_size)
         cuda_tracker = engine.create_tracker() if args.track else None
 
         def _run_cuda():
@@ -297,16 +860,70 @@ def main(argv: list[str] | None = None) -> int:
                 )
             return engine.predict(prepared_input, conf=float(args.conf))[0]
 
-        _benchmark_runner(
-            "cuda-track" if args.track else "cuda",
+        name = "cuda-track" if args.track else "cuda"
+        document["results"][name] = _benchmark_runner(
+            name,
             _run_cuda,
-            runs=int(args.runs),
-            warmup=int(args.warmup),
+            runs=runs,
+            warmup=warmup,
             profile_allocations=bool(args.profile_allocations),
             allocation_top=int(args.allocation_top),
         )
 
+    if "camera" in selected_modes:
+        try:
+            camera_fp16 = bool(getattr(engine, "_main_fp16"))
+        except Exception:
+            camera_fp16 = False
+        camera_source = _camera_source_from_spec(
+            str(args.camera_source),
+            width=args.camera_width,
+            height=args.camera_height,
+            fps=args.camera_fps,
+            timeout_s=float(args.camera_timeout),
+            prefix="benchmark_camera",
+            max_frames=warmup + runs,
+            zero_copy=_camera_zero_copy_value(str(args.camera_zero_copy)),
+            target_imgsz=target_size,
+            fp16=camera_fp16,
+            device=args.device,
+        )
+        camera_frames = iter(camera_source)
+        camera_tracker = engine.create_tracker() if args.track else None
+
+        def _run_camera():
+            try:
+                frame = next(camera_frames)
+            except StopIteration as exc:
+                raise RuntimeError(
+                    f"Camera benchmark source ended before {warmup + runs} required frame(s) were available"
+                ) from exc
+            if camera_tracker is not None:
+                return camera_tracker.update(
+                    frame,
+                    source_key="benchmark-camera",
+                    imgsz=target_size,
+                    conf=float(args.conf),
+                )
+            return engine.predict_item(frame, imgsz=target_size, conf=float(args.conf))
+
+        name = "camera-track" if args.track else "camera"
+        try:
+            document["results"][name] = _benchmark_runner(
+                name,
+                _run_camera,
+                runs=runs,
+                warmup=warmup,
+                profile_allocations=bool(args.profile_allocations),
+                allocation_top=int(args.allocation_top),
+            )
+        finally:
+            _close_if_available(camera_frames)
+            if camera_frames is not camera_source:
+                _close_if_available(camera_source)
+
     if args.visual_prompts != "none":
+        item = _benchmark_item()
         visual_prompt_inputs = _build_visual_prompt_inputs(item.image, labels[0])
         visual_modes = ["bbox", "mask"] if args.visual_prompts == "both" else [str(args.visual_prompts)]
         visual_runtime_labels: list[tuple[str, object]] = []
@@ -325,23 +942,41 @@ def main(argv: list[str] | None = None) -> int:
         for runtime_name, visual_engine in visual_runtime_labels:
             for visual_mode in visual_modes:
                 prompt_kwargs = visual_prompt_inputs[visual_mode]
-                for _ in range(int(args.warmup)):
+
+                def _run_visual_prompt():
                     with _suppress_info_logs_for_timing():
-                        visual_engine.clear_prompts()
                         visual_engine.set_visual_prompts(item.image, imgsz=target_size, **prompt_kwargs)
                         _synchronize_engine_device(visual_engine)
+                    return None
 
-                latencies_ms: list[float] = []
-                for _ in range(int(args.runs)):
+                def _setup_visual_prompt():
                     with _suppress_info_logs_for_timing():
                         visual_engine.clear_prompts()
-                        start = time.perf_counter()
-                        visual_engine.set_visual_prompts(item.image, imgsz=target_size, **prompt_kwargs)
-                        _synchronize_engine_device(visual_engine)
-                    latencies_ms.append((time.perf_counter() - start) * 1000.0)
 
-                print(f"visual-{runtime_name}-{visual_mode}: runs={int(args.runs)} {_format_ms(latencies_ms)}")
+                name = f"visual-{runtime_name}-{visual_mode}"
+                document["results"][name] = _benchmark_runner(
+                    name,
+                    _run_visual_prompt,
+                    runs=runs,
+                    warmup=warmup,
+                    profile_allocations=False,
+                    allocation_top=0,
+                    setup=_setup_visual_prompt,
+                )
 
+    if args.compare_to is not None:
+        assert baseline is not None
+        comparison = _compare_benchmark_results(document, baseline, _comparison_thresholds(args))
+        document["comparison"] = comparison
+        document["comparison"]["baseline_path"] = str(args.compare_to)
+        _print_comparison_summary(comparison, Path(args.compare_to))
+    if not args.no_save:
+        output_path = _write_benchmark_json(document, args.output_dir, args.output_name)
+        print(f"benchmark JSON: {output_path}")
+
+    comparison = document.get("comparison")
+    if args.fail_on_regression and comparison is not None and comparison["status"] != "ok":
+        return 1
     return 0
 
 


### PR DESCRIPTION
  - Added structured JSON output for yoloe-benchmark, saved under outputs/benchmarks/ by default.
  - Added benchmark modes for host input, prepared CUDA input, camera input, both, and all.
  - Added Jetson camera benchmark options for source, resolution, FPS, timeout, and zero-copy policy.
  - Added aggregate latency, FPS, speed breakdown, process CPU, and system CPU reporting.
  - Added optional Python allocation profiling to benchmark result output.
  - Added baseline comparison support with configurable latency, FPS, and CPU regression thresholds.
  - Added CI-friendly failure behavior for regressions, no-overlap comparisons, and comparisons with no usable metrics.
  - Preserved visual-prompt benchmark timing semantics while including visual results in JSON output.
  - Added benchmark documentation and README/development docs updates.
  - Expanded CLI tests for JSON output, camera mode, comparison gates, CPU metrics, output naming, and --mode all.
