### PR TITLE
docs: documented runtime benchmark matrix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Unified `predict(...)` and `track(...)` around a single broad input surface with specialized internal routing for paths, arrays, raw tensors, prepared CUDA tensors, and live sources.
 - Added `PreparedTensorInput`, a prepared CUDA-tensor fast path, and a `benchmark` CLI for comparing host-image and CUDA-tensor inference through the native TensorRT runtime.
 - Added reproducible Jetson benchmark output with JSON result files, CPU utilization metrics, camera-path timing, and optional baseline comparison.
+- Documented the runtime benchmark matrix and added text-prompt update timing to the benchmark CLI.
 - Extended tracker sessions to use the unified input router, support prepared tensor updates, and preserve the artifact default `max_det` behavior.
 - Fixed prepared-tensor correctness issues around integer dtype validation, CUDA producer-stream handoff, and cross-stream prepared-tensor inference.
 - Fixed unit-range float preprocessing so non-square padded inputs keep the correct scale instead of being divided by `255` a second time.

--- a/README.md
+++ b/README.md
@@ -191,6 +191,9 @@ yoloe-benchmark outputs/artifacts/yoloe26s tests/assets/images/bus.jpg \
   --label bus --mode camera --camera-source /dev/video0 --camera-zero-copy auto
 ```
 
+See [Benchmarks](docs/benchmarks.md) for the full runtime matrix covering CPU-memory input, CUDA-tensor input, Jetson
+zero-copy camera input, text-prompt update cost, and visual-prompt update cost.
+
 ## CI/CD
 
 GitHub Actions is the supported automation path for this repository.

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -1,37 +1,87 @@
 # Benchmarks
 
-`yoloe-benchmark` measures runtime inference paths and writes structured JSON output under `outputs/benchmarks/` by
-default. It reports latency, FPS, measured-loop process CPU utilization, and measured-loop total system CPU utilization
-for each measured path.
+`yoloe-benchmark` measures runtime inference paths and prompt update operations, then writes structured JSON output under
+`outputs/benchmarks/` by default. It reports latency, FPS, measured-loop process CPU utilization, and measured-loop total
+system CPU utilization for each measured path.
 
-## Host and CUDA paths
+Use the same artifact, image, labels, `--imgsz`, `--runs`, and `--warmup` when comparing results across commits or
+devices. The positional image is used by inference and visual-prompt benchmarks; text-only benchmarks accept it for CLI
+consistency but do not decode it.
+
+## Benchmark matrix
+
+| Coverage | Command | Result key | Output |
+| --- | --- | --- | --- |
+| CPU-memory input path | `--mode host` | `host` | `outputs/benchmarks/matrix-host.json` |
+| CUDA-tensor input path | `--mode cuda` | `cuda` | `outputs/benchmarks/matrix-cuda.json` |
+| Jetson zero-copy camera path | `--mode camera --camera-zero-copy required` | `camera` | `outputs/benchmarks/matrix-camera.json` |
+| Text-prompt update cost | `--mode none --text-prompts` | `text-set-classes` | `outputs/benchmarks/matrix-text-prompts.json` |
+| Visual-prompt update cost | `--mode none --visual-prompts both --visual-runtime both` | `visual-native-bbox`, `visual-native-mask`, `visual-python-bbox`, `visual-python-mask` when available | `outputs/benchmarks/matrix-visual-prompts.json` |
+
+## Commands
+
+CPU-memory input path:
 
 ```bash
 yoloe-benchmark outputs/artifacts/yoloe26s tests/assets/images/bus.jpg \
-  --label bus --mode both --runs 200 --warmup 20
+  --label bus --mode host --runs 200 --warmup 20 \
+  --output-name matrix-host
 ```
 
-`--mode both` preserves the historical behavior and runs only the host-memory image path plus the prepared CUDA tensor
-path.
+CUDA-tensor input path:
 
-## Jetson camera path
+```bash
+yoloe-benchmark outputs/artifacts/yoloe26s tests/assets/images/bus.jpg \
+  --label bus --mode cuda --runs 200 --warmup 20 \
+  --output-name matrix-cuda
+```
+
+Jetson zero-copy camera path:
 
 ```bash
 yoloe-benchmark outputs/artifacts/yoloe26s tests/assets/images/bus.jpg \
   --label bus --mode camera --camera-source /dev/video0 \
-  --camera-zero-copy auto --runs 200 --warmup 20
+  --camera-zero-copy required --runs 200 --warmup 20 \
+  --output-name matrix-camera
 ```
 
-Camera mode opens the live source once and consumes `warmup + runs` frames. Use `--camera-zero-copy required` when the
-benchmark must fail instead of falling back to the CPU appsink path.
+Text-prompt update cost:
 
-## JSON output
+```bash
+yoloe-benchmark outputs/artifacts/yoloe26s tests/assets/images/bus.jpg \
+  --label bus --label person --mode none --text-prompts \
+  --runs 50 --warmup 5 --output-name matrix-text-prompts
+```
+
+Visual-prompt update cost:
+
+```bash
+yoloe-benchmark outputs/artifacts/yoloe26s tests/assets/images/bus.jpg \
+  --label bus --mode none --visual-prompts both --visual-runtime both \
+  --runs 50 --warmup 5 --output-name matrix-visual-prompts
+```
+
+`--mode both` runs the historical host plus CUDA pair. `--mode all` runs host, CUDA, and camera paths, and therefore
+requires `--camera-source`. Use `--mode none` only with `--text-prompts` or `--visual-prompts` for prompt-update-only
+benchmarks.
+
+## Output and interpretation
 
 Each JSON file contains:
 
 - `schema_version`, `created_at`, `package_version`, and platform metadata
-- `config` with artifact, labels, image size, run counts, tracking, and camera settings
+- `config` with artifact, labels, image size, run counts, tracking, prompt, and camera settings
 - `results` keyed by mode, with `latency_ms`, `fps`, `speed_ms`, `cpu`, and optional `allocations`
+
+For inference paths, compare `latency_ms.median`, `latency_ms.p95`, `fps`, `speed_ms.inference.mean`,
+`cpu.process_percent.mean`, and `cpu.system_percent.mean`. For prompt-update rows, `latency_ms` is the update cost;
+`speed_ms` is inference-specific and should not be used as the prompt-update metric.
+
+Camera mode opens the live source once and consumes `warmup + runs` frames. Use `--camera-zero-copy required` for
+regression baselines so an accidental CPU appsink fallback fails instead of polluting the zero-copy result.
+
+Use `--profile-allocations` when checking Python steady-state allocation pressure. The `allocations` object reports
+retained Python allocations and traced peak memory for that measured loop.
 
 Disable file output with `--no-save`, or choose the location with `--output-dir` and `--output-name`.
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -85,6 +85,9 @@ yoloe-benchmark outputs/artifacts/yoloe26s tests/assets/images/bus.jpg \
 Add `--fail-on-regression` to make the command exit non-zero when the configured latency, FPS, or CPU thresholds are
 exceeded, or when the comparison is invalid because no modes or no metrics were compared.
 
+The full benchmark matrix, including text-prompt and visual-prompt update costs, is documented in
+[Benchmarks](benchmarks.md).
+
 ## CI and release automation
 
 - Public CI runs Ruff, runner-safe unit tests, docs validation, sdist builds, and clean install smoke tests.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -76,6 +76,7 @@ def test_benchmark_cli_displays_help() -> None:
     assert result.returncode == 0
     assert "Benchmark YOLOE TensorRT runtime paths" in result.stdout
     assert "--mode" in result.stdout
+    assert "--text-prompts" in result.stdout
     assert "--visual-prompts" in result.stdout
     assert "--profile-allocations" in result.stdout
     assert "--track" in result.stdout
@@ -84,6 +85,7 @@ def test_benchmark_cli_displays_help() -> None:
     assert "--output-dir" in result.stdout
     assert "--compare-to" in result.stdout
     assert "invalid comparison" in result.stdout
+    assert "not decoded for text-only benchmarks" in result.stdout
 
 
 def test_benchmark_runner_profiles_allocations(capsys) -> None:
@@ -276,6 +278,213 @@ def test_benchmark_main_writes_json_output(monkeypatch: pytest.MonkeyPatch, tmp_
     assert payload["config"]["mode"] == "both"
     assert set(payload["results"]) == {"host", "cuda"}
     assert payload["results"]["host"]["latency_ms"]["count"] == 1
+
+
+def test_benchmark_none_mode_requires_prompt_benchmark(tmp_path: Path) -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        benchmark_cli.main(
+            [
+                str(tmp_path / "artifact"),
+                str(tmp_path / "image.jpg"),
+                "--mode",
+                "none",
+                "--runs",
+                "1",
+                "--warmup",
+                "0",
+                "--no-save",
+            ]
+        )
+
+    assert exc_info.value.code == 2
+
+
+def test_benchmark_text_prompts_writes_prompt_only_json(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    class _Engine:
+        native_visual_runtime = None
+        device = "cpu"
+
+        def __init__(self) -> None:
+            self.calls: list[tuple[str, tuple[str, ...]]] = []
+
+        def clear_prompts(self) -> None:
+            self.calls.append(("clear_prompts", ()))
+
+        def set_classes(self, labels: list[str]) -> None:
+            self.calls.append(("set_classes", tuple(labels)))
+
+    engine = _Engine()
+    sync_calls = {"count": 0}
+
+    monkeypatch.setattr(benchmark_cli, "_build_engine", lambda *_args, **_kwargs: engine)
+    monkeypatch.setattr(
+        benchmark_cli,
+        "_synchronize_engine_device",
+        lambda _engine: sync_calls.__setitem__("count", sync_calls["count"] + 1),
+    )
+    monkeypatch.setattr(
+        "yoloe_tensorrt.source.normalize_source",
+        lambda *_args, **_kwargs: pytest.fail("text-only benchmark should not decode the image argument"),
+    )
+
+    result = benchmark_cli.main(
+        [
+            str(tmp_path / "artifact"),
+            str(tmp_path / "image.jpg"),
+            "--label",
+            "bus",
+            "--label",
+            "person",
+            "--mode",
+            "none",
+            "--text-prompts",
+            "--runs",
+            "1",
+            "--warmup",
+            "1",
+            "--output-dir",
+            str(tmp_path / "benchmarks"),
+            "--output-name",
+            "text-result",
+            "--log-level",
+            "WARNING",
+        ]
+    )
+
+    payload = json.loads((tmp_path / "benchmarks" / "text-result.json").read_text())
+    assert result == 0
+    assert set(payload["results"]) == {"text-set-classes"}
+    assert payload["config"]["text_prompts"] is True
+    assert payload["config"]["mode"] == "none"
+    assert payload["results"]["text-set-classes"]["latency_ms"]["count"] == 1
+    assert engine.calls == [
+        ("clear_prompts", ()),
+        ("set_classes", ("bus", "person")),
+        ("clear_prompts", ()),
+        ("set_classes", ("bus", "person")),
+        ("clear_prompts", ()),
+        ("set_classes", ("bus", "person")),
+    ]
+    assert sync_calls["count"] == 3
+
+
+def test_benchmark_none_mode_allows_visual_prompt_only_json(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    class _Engine:
+        native_visual_runtime = object()
+        visual_runtime = None
+        device = "cpu"
+
+        def __init__(self) -> None:
+            self.visual_calls = 0
+            self.text_calls = 0
+
+        def clear_prompts(self) -> None:
+            pass
+
+        def set_classes(self, _labels: list[str]) -> None:
+            self.text_calls += 1
+
+        def set_visual_prompts(self, *_args, **_kwargs) -> None:
+            self.visual_calls += 1
+
+    image = np.zeros((4, 4, 3), dtype=np.uint8)
+    engine = _Engine()
+
+    monkeypatch.setattr(benchmark_cli, "_build_engine", lambda *_args, **_kwargs: engine)
+    monkeypatch.setattr(benchmark_cli, "_synchronize_engine_device", lambda _engine: None)
+    monkeypatch.setattr(
+        "yoloe_tensorrt.source.normalize_source",
+        lambda *_args, **_kwargs: [SourceItem(image=image, path="benchmark0")],
+    )
+
+    result = benchmark_cli.main(
+        [
+            str(tmp_path / "artifact"),
+            str(tmp_path / "image.jpg"),
+            "--mode",
+            "none",
+            "--visual-prompts",
+            "bbox",
+            "--visual-runtime",
+            "native",
+            "--runs",
+            "1",
+            "--warmup",
+            "0",
+            "--output-dir",
+            str(tmp_path / "benchmarks"),
+            "--output-name",
+            "visual-result",
+            "--log-level",
+            "WARNING",
+        ]
+    )
+
+    payload = json.loads((tmp_path / "benchmarks" / "visual-result.json").read_text())
+    assert result == 0
+    assert set(payload["results"]) == {"visual-native-bbox"}
+    assert payload["config"]["mode"] == "none"
+    assert payload["config"]["visual_prompts"] == "bbox"
+    assert engine.visual_calls == 1
+    assert engine.text_calls == 0
+
+
+def test_benchmark_none_mode_rejects_visual_prompt_without_runtime(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    class _Engine:
+        native_visual_runtime = None
+        visual_runtime = None
+        device = "cpu"
+
+        def __init__(self) -> None:
+            self.text_calls = 0
+
+        def clear_prompts(self) -> None:
+            pass
+
+        def set_classes(self, _labels: list[str]) -> None:
+            self.text_calls += 1
+
+    engine = _Engine()
+
+    monkeypatch.setattr(benchmark_cli, "_build_engine", lambda *_args, **_kwargs: engine)
+    monkeypatch.setattr(benchmark_cli, "_synchronize_engine_device", lambda _engine: None)
+
+    with pytest.raises(SystemExit) as exc_info:
+        benchmark_cli.main(
+            [
+                str(tmp_path / "artifact"),
+                str(tmp_path / "image.jpg"),
+                "--mode",
+                "none",
+                "--visual-prompts",
+                "bbox",
+                "--visual-runtime",
+                "native",
+                "--runs",
+                "1",
+                "--warmup",
+                "0",
+                "--output-dir",
+                str(tmp_path / "benchmarks"),
+                "--output-name",
+                "empty-result",
+                "--log-level",
+                "WARNING",
+            ]
+        )
+
+    assert exc_info.value.code == 2
+    assert not (tmp_path / "benchmarks" / "empty-result.json").exists()
+    assert engine.text_calls == 0
 
 
 def test_benchmark_all_mode_writes_host_cuda_and_camera_results(

--- a/yoloe_tensorrt/benchmark_cli.py
+++ b/yoloe_tensorrt/benchmark_cli.py
@@ -26,11 +26,16 @@ from .logging_utils import configure_logging
 def build_arg_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description=(
-            "Benchmark YOLOE TensorRT runtime paths, camera ingest, visual-prompt updates, and JSON regression output."
+            "Benchmark YOLOE TensorRT runtime paths, camera ingest, prompt updates, and JSON regression output."
         )
     )
     parser.add_argument("artifact_dir", help="Artifact bundle directory to benchmark.")
-    parser.add_argument("image", help="Image path to use for repeated benchmark runs.")
+    parser.add_argument(
+        "image",
+        help=(
+            "Image path for inference and visual-prompt benchmarks; accepted but not decoded for text-only benchmarks."
+        ),
+    )
     parser.add_argument(
         "--label",
         action="append",
@@ -43,9 +48,9 @@ def build_arg_parser() -> argparse.ArgumentParser:
     parser.add_argument("--warmup", type=int, default=5, help="Warmup iterations per mode. Defaults to 5.")
     parser.add_argument(
         "--mode",
-        choices=("host", "cuda", "camera", "both", "all"),
+        choices=("none", "host", "cuda", "camera", "both", "all"),
         default="both",
-        help="Benchmark the host-image path, CUDA fast path, camera path, host+CUDA, or all paths.",
+        help="Benchmark no inference path, host-image path, CUDA fast path, camera path, host+CUDA, or all paths.",
     )
     parser.add_argument("--conf", type=float, default=0.25, help="Detection confidence threshold.")
     parser.add_argument("--device", default="cuda:0", help="Torch/TensorRT device. Defaults to cuda:0.")
@@ -116,6 +121,11 @@ def build_arg_parser() -> argparse.ArgumentParser:
         choices=("auto", "required", "off"),
         default="auto",
         help="Camera zero-copy policy for Jetson sources.",
+    )
+    parser.add_argument(
+        "--text-prompts",
+        action="store_true",
+        help="Also benchmark set_classes() text-prompt updates.",
     )
     parser.add_argument(
         "--visual-prompts",
@@ -412,6 +422,8 @@ def _benchmark_runner(
 
 
 def _selected_modes(mode: str) -> list[str]:
+    if mode == "none":
+        return []
     if mode == "both":
         return ["host", "cuda"]
     if mode == "all":
@@ -468,6 +480,9 @@ def _benchmark_metadata(args: argparse.Namespace, created_at: str) -> dict[str, 
             "track": bool(args.track),
             "conf": float(args.conf),
             "device": str(args.device),
+            "text_prompts": bool(args.text_prompts),
+            "visual_prompts": str(args.visual_prompts),
+            "visual_runtime": str(args.visual_runtime),
             "camera": {
                 "source": args.camera_source,
                 "width": args.camera_width,
@@ -776,7 +791,7 @@ def _suppress_info_logs_for_timing():
 def _synchronize_engine_device(engine: object) -> None:
     import torch
 
-    device = torch.device(getattr(engine, "device", "cuda:0"))
+    device = torch.device(getattr(engine, "device", "cpu"))
     if device.type == "cuda":
         torch.cuda.synchronize(device)
 
@@ -791,6 +806,8 @@ def main(argv: list[str] | None = None) -> int:
         parser.error("--runs must be greater than 0")
     if warmup < 0:
         parser.error("--warmup must be greater than or equal to 0")
+    if not selected_modes and not args.text_prompts and args.visual_prompts == "none":
+        parser.error("--mode none requires --text-prompts or --visual-prompts")
     if "camera" in selected_modes and not args.camera_source:
         parser.error("--camera-source is required when --mode is 'camera' or 'all'")
     if args.compare_to is not None and not Path(args.compare_to).is_file():
@@ -816,7 +833,9 @@ def main(argv: list[str] | None = None) -> int:
     artifact_dir = Path(args.artifact_dir)
     engine = _build_engine(artifact_dir, args.device)
     engine.clear_prompts()
-    engine.set_classes(labels)
+    if selected_modes or args.text_prompts:
+        engine.set_classes(labels)
+        _synchronize_engine_device(engine)
 
     item = None
 
@@ -825,6 +844,28 @@ def main(argv: list[str] | None = None) -> int:
         if item is None:
             item = normalize_source(Path(args.image), default_prefix="benchmark")[0]
         return item
+
+    if args.text_prompts:
+
+        def _run_text_prompt():
+            with _suppress_info_logs_for_timing():
+                engine.set_classes(labels)
+                _synchronize_engine_device(engine)
+            return None
+
+        def _setup_text_prompt():
+            with _suppress_info_logs_for_timing():
+                engine.clear_prompts()
+
+        document["results"]["text-set-classes"] = _benchmark_runner(
+            "text-set-classes",
+            _run_text_prompt,
+            runs=runs,
+            warmup=warmup,
+            profile_allocations=bool(args.profile_allocations),
+            allocation_top=int(args.allocation_top),
+            setup=_setup_text_prompt,
+        )
 
     host_tracker = engine.create_tracker() if args.track and "host" in selected_modes else None
 
@@ -923,8 +964,6 @@ def main(argv: list[str] | None = None) -> int:
                 _close_if_available(camera_source)
 
     if args.visual_prompts != "none":
-        item = _benchmark_item()
-        visual_prompt_inputs = _build_visual_prompt_inputs(item.image, labels[0])
         visual_modes = ["bbox", "mask"] if args.visual_prompts == "both" else [str(args.visual_prompts)]
         visual_runtime_labels: list[tuple[str, object]] = []
         if args.visual_runtime in {"native", "both"}:
@@ -939,30 +978,36 @@ def main(argv: list[str] | None = None) -> int:
             else:
                 print("visual-python: skipped (Python visual runtime unavailable)")
 
-        for runtime_name, visual_engine in visual_runtime_labels:
-            for visual_mode in visual_modes:
-                prompt_kwargs = visual_prompt_inputs[visual_mode]
+        if visual_runtime_labels:
+            item = _benchmark_item()
+            visual_prompt_inputs = _build_visual_prompt_inputs(item.image, labels[0])
+            for runtime_name, visual_engine in visual_runtime_labels:
+                for visual_mode in visual_modes:
+                    prompt_kwargs = visual_prompt_inputs[visual_mode]
 
-                def _run_visual_prompt():
-                    with _suppress_info_logs_for_timing():
-                        visual_engine.set_visual_prompts(item.image, imgsz=target_size, **prompt_kwargs)
-                        _synchronize_engine_device(visual_engine)
-                    return None
+                    def _run_visual_prompt():
+                        with _suppress_info_logs_for_timing():
+                            visual_engine.set_visual_prompts(item.image, imgsz=target_size, **prompt_kwargs)
+                            _synchronize_engine_device(visual_engine)
+                        return None
 
-                def _setup_visual_prompt():
-                    with _suppress_info_logs_for_timing():
-                        visual_engine.clear_prompts()
+                    def _setup_visual_prompt():
+                        with _suppress_info_logs_for_timing():
+                            visual_engine.clear_prompts()
 
-                name = f"visual-{runtime_name}-{visual_mode}"
-                document["results"][name] = _benchmark_runner(
-                    name,
-                    _run_visual_prompt,
-                    runs=runs,
-                    warmup=warmup,
-                    profile_allocations=False,
-                    allocation_top=0,
-                    setup=_setup_visual_prompt,
-                )
+                    name = f"visual-{runtime_name}-{visual_mode}"
+                    document["results"][name] = _benchmark_runner(
+                        name,
+                        _run_visual_prompt,
+                        runs=runs,
+                        warmup=warmup,
+                        profile_allocations=False,
+                        allocation_top=0,
+                        setup=_setup_visual_prompt,
+                    )
+
+    if not document["results"]:
+        parser.error("no benchmark results were produced; check --mode and prompt benchmark runtime availability")
 
     if args.compare_to is not None:
         assert baseline is not None


### PR DESCRIPTION
  - Documented the runtime benchmark matrix for CPU-memory input, CUDA-tensor input, Jetson zero-copy camera input, text-prompt updates, and visual-prompt updates.
  - Added exact benchmark commands, output filenames, result keys, and interpretation guidance in the benchmark docs.
  - Added --text-prompts to yoloe-benchmark for timing set_classes(...) text prompt updates.
  - Added --mode none for prompt-only benchmark runs without host/CUDA/camera inference.
  - Added safeguards so prompt-only visual benchmarks fail when no visual runtime is available instead of writing empty results.
  - Avoided unnecessary text prompt compilation and image decoding in prompt-only benchmark paths.
  - Updated README, development docs, and changelog references for the benchmark matrix.
  - Added CLI tests for text prompt timing, prompt-only mode validation, visual prompt-only behavior, and empty-result failure cases.