### PR TITLE
feat: added fine-tuning and training API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Added a package-level `train_model(...)` API for YOLOE training and fine-tuning through Ultralytics.
 - Added YOLOE dataset config validation helpers for Ultralytics-style detection and segmentation training inputs.
 
 ## 0.2.0

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,6 +25,7 @@ the main inference hot path into a native backend.
 - `yoloe-export`
 - `yoloe-camera-gui`
 - `yoloe-benchmark`
+- `train_model(...)`
 - `validate_dataset_config(...)`
 - `python -m yoloe_tensorrt`
 

--- a/docs/training.md
+++ b/docs/training.md
@@ -1,11 +1,51 @@
-# Training Data
+# Training
 
-`yoloe-tensorrt` keeps training and fine-tuning execution delegated to Ultralytics, but it provides a preflight helper for
-checking YOLOE dataset configs before training starts.
+`yoloe-tensorrt` delegates YOLOE training and fine-tuning to Ultralytics while providing a package-level API that
+validates dataset configs before launching a run.
+
+## Train or fine-tune
+
+Use `train_model(...)` when you want the package to validate the dataset and call Ultralytics for you:
+
+```python
+from yoloe_tensorrt import train_model
+
+result = train_model(
+    "yoloe-26s-seg.pt",
+    "data.yaml",
+    task="segment",
+    imgsz=640,
+    epochs=50,
+    batch=8,
+    device="cuda:0",
+)
+
+print(result.checkpoint_path)
+print(result.run_dir)
+```
+
+By default, run outputs are placed under `outputs/training`. The result includes the selected checkpoint path, the
+Ultralytics run directory, an optional metrics file path when one exists, and basic metadata about the run.
+
+Pass advanced Ultralytics trainer options with `overrides`:
+
+```python
+result = train_model(
+    "yoloe-26s-seg.pt",
+    "data.yaml",
+    overrides={"workers": 4, "optimizer": "AdamW", "lr0": 0.001},
+)
+```
+
+Ultralytics keys controlled by the wrapper are reserved in `overrides`. Pass `data` as `dataset_config`, `project` as
+`output_dir`, and use the explicit `task`, `imgsz`, `epochs`, `batch`, `device`, and `name` arguments.
+
+For advanced Ultralytics workflows that need a custom trainer, nonstandard save behavior, or distributed training
+orchestration, call Ultralytics directly.
 
 ## Validate a dataset config
 
-Use `validate_dataset_config(...)` with an Ultralytics-style dataset YAML:
+Use `validate_dataset_config(...)` directly when you only need a preflight check:
 
 ```python
 from yoloe_tensorrt import validate_dataset_config
@@ -15,15 +55,11 @@ print(dataset.names)
 print(dataset.train.image_count, dataset.val.image_count)
 ```
 
-For segmentation datasets, set `task="segment"`:
-
-```python
-dataset = validate_dataset_config("data.yaml", task="segment")
-```
+For segmentation datasets, set `task="segment"`.
 
 ## Supported config shape
 
-The helper supports the standard YOLO dataset fields:
+The training and validation helpers support the standard YOLO dataset fields:
 
 ```yaml
 path: /data/my-dataset
@@ -48,5 +84,4 @@ provided, otherwise against the YAML file directory.
 - Segmentation labels must use `class x1 y1 x2 y2 ...` with at least three polygon points.
 - Label class IDs must be in range and coordinates must be finite normalized values in `[0, 1]`.
 
-Validation does not create generated outputs. If future training helpers write reports or artifacts, they should place
-them under `outputs/`.
+Dataset validation alone does not create generated outputs.

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -1,0 +1,374 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+import yaml
+import yoloe_tensorrt
+from yoloe_tensorrt import TrainingError, TrainingResult, train_model, training
+from yoloe_tensorrt.datasets import DatasetConfig, DatasetSplit
+
+
+class _FakeYOLOE:
+    instances: list["_FakeYOLOE"] = []
+    trainer: Any = None
+    metrics: Any = {"map50": 0.5}
+
+    def __init__(self, model: str, task: str | None = None) -> None:
+        self.model = model
+        self.task = task
+        self.train_kwargs: dict[str, Any] | None = None
+        type(self).instances.append(self)
+
+    def train(self, **kwargs: Any) -> Any:
+        self.train_kwargs = kwargs
+        self.trainer = type(self).trainer
+        return type(self).metrics
+
+
+def _make_dataset_config(tmp_path: Path) -> Path:
+    root = tmp_path / "dataset"
+    for split in ("train", "val"):
+        image_dir = root / "images" / split
+        label_dir = root / "labels" / split
+        image_dir.mkdir(parents=True)
+        label_dir.mkdir(parents=True)
+        (image_dir / "img0.jpg").write_bytes(b"")
+        (label_dir / "img0.txt").write_text("0 0.5 0.5 0.25 0.25\n", encoding="utf-8")
+
+    config_path = tmp_path / "data.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "path": "dataset",
+                "train": "images/train",
+                "val": "images/val",
+                "names": ["person"],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return config_path
+
+
+def _make_dataset_result(tmp_path: Path) -> DatasetConfig:
+    split = DatasetSplit(
+        name="train",
+        images=(tmp_path / "dataset" / "images" / "train",),
+        labels=(tmp_path / "dataset" / "labels" / "train",),
+        image_count=2,
+        label_count=2,
+    )
+    return DatasetConfig(
+        yaml_path=tmp_path / "data.yaml",
+        root=tmp_path / "dataset",
+        task="detect",
+        names={0: "person"},
+        train=split,
+        val=DatasetSplit(
+            name="val",
+            images=(tmp_path / "dataset" / "images" / "val",),
+            labels=(tmp_path / "dataset" / "labels" / "val",),
+            image_count=1,
+            label_count=1,
+        ),
+    )
+
+
+def _install_fake_yoloe(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    trainer: Any,
+    metrics: Any = {"map50": 0.5},
+) -> type[_FakeYOLOE]:
+    _FakeYOLOE.instances.clear()
+    _FakeYOLOE.trainer = trainer
+    _FakeYOLOE.metrics = metrics
+    monkeypatch.setattr(training, "_load_yoloe_class", lambda: _FakeYOLOE)
+    return _FakeYOLOE
+
+
+def test_train_model_validates_dataset_and_calls_ultralytics(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    dataset_path = tmp_path / "data.yaml"
+    model_path = tmp_path / "model.pt"
+    output_dir = tmp_path / "runs"
+    run_dir = output_dir / "custom"
+    weights_dir = run_dir / "weights"
+    weights_dir.mkdir(parents=True)
+    best_path = weights_dir / "best.pt"
+    last_path = weights_dir / "last.pt"
+    best_path.write_bytes(b"best")
+    last_path.write_bytes(b"last")
+    metrics_path = run_dir / "results.csv"
+    metrics_path.write_text("metrics\n", encoding="utf-8")
+
+    validation_calls: list[tuple[Path, str]] = []
+
+    def _fake_validate(config: str | Path, *, task: str) -> DatasetConfig:
+        validation_calls.append((Path(config), task))
+        return _make_dataset_result(tmp_path)
+
+    monkeypatch.setattr(training, "validate_dataset_config", _fake_validate)
+    fake_yoloe = _install_fake_yoloe(
+        monkeypatch,
+        trainer=SimpleNamespace(save_dir=run_dir, best=best_path, last=last_path),
+        metrics=SimpleNamespace(),
+    )
+
+    result = train_model(
+        model_path,
+        dataset_path,
+        task="detect",
+        imgsz=320,
+        epochs=3,
+        batch=4,
+        device="cuda:0",
+        output_dir=output_dir,
+        name="custom",
+        exist_ok=True,
+    )
+
+    assert isinstance(result, TrainingResult)
+    assert validation_calls == [(dataset_path, "detect")]
+    assert result.checkpoint_path == best_path.resolve()
+    assert result.run_dir == run_dir.resolve()
+    assert result.metrics_path == metrics_path.resolve()
+    assert result.metadata["dataset"] == {
+        "root": str(tmp_path / "dataset"),
+        "names": {0: "person"},
+        "train_image_count": 2,
+        "val_image_count": 1,
+        "test_image_count": None,
+    }
+    assert result.metadata["metrics_type"] == "SimpleNamespace"
+
+    instance = fake_yoloe.instances[0]
+    assert instance.model == str(model_path)
+    assert instance.task == "detect"
+    assert instance.train_kwargs == {
+        "data": str(dataset_path),
+        "task": "detect",
+        "imgsz": 320,
+        "epochs": 3,
+        "batch": 4,
+        "project": str(output_dir),
+        "exist_ok": True,
+        "device": "cuda:0",
+        "name": "custom",
+    }
+
+
+def test_train_model_merges_non_conflicting_ultralytics_overrides(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    dataset_path = _make_dataset_config(tmp_path)
+    run_dir = tmp_path / "runs" / "train"
+    weights_dir = run_dir / "weights"
+    weights_dir.mkdir(parents=True)
+    (weights_dir / "best.pt").write_bytes(b"best")
+    fake_yoloe = _install_fake_yoloe(
+        monkeypatch,
+        trainer=SimpleNamespace(save_dir=run_dir, best=weights_dir / "best.pt", last=weights_dir / "last.pt"),
+    )
+
+    train_model(
+        "yoloe-26s-seg.pt",
+        dataset_path,
+        overrides={"workers": 2, "optimizer": "AdamW", "lr0": 0.001},
+    )
+
+    assert fake_yoloe.instances[0].train_kwargs["workers"] == 2
+    assert fake_yoloe.instances[0].train_kwargs["optimizer"] == "AdamW"
+    assert fake_yoloe.instances[0].train_kwargs["lr0"] == 0.001
+
+
+@pytest.mark.parametrize("save_value", [False, 0])
+def test_train_model_rejects_falsey_save_override(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    save_value: bool | int,
+) -> None:
+    dataset_path = _make_dataset_config(tmp_path)
+    _install_fake_yoloe(monkeypatch, trainer=SimpleNamespace())
+
+    with pytest.raises(ValueError, match="requires Ultralytics to save checkpoints"):
+        train_model("model.pt", dataset_path, overrides={"save": save_value})
+
+    assert _FakeYOLOE.instances == []
+
+
+def test_train_model_rejects_invalid_override_keys(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    dataset_path = _make_dataset_config(tmp_path)
+    _install_fake_yoloe(monkeypatch, trainer=SimpleNamespace())
+
+    with pytest.raises(ValueError, match="must be non-empty strings"):
+        train_model("model.pt", dataset_path, overrides={1: "workers"})  # type: ignore[dict-item]
+
+    assert _FakeYOLOE.instances == []
+
+
+@pytest.mark.parametrize("conflicting_key", ["data", "task", "imgsz", "epochs", "batch", "device", "project", "name"])
+def test_train_model_rejects_conflicting_overrides(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    conflicting_key: str,
+) -> None:
+    dataset_path = _make_dataset_config(tmp_path)
+    _install_fake_yoloe(monkeypatch, trainer=SimpleNamespace())
+
+    with pytest.raises(ValueError, match="conflict with train_model"):
+        train_model("model.pt", dataset_path, overrides={conflicting_key: "override"})
+
+    assert _FakeYOLOE.instances == []
+
+
+def test_train_model_falls_back_to_last_checkpoint(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    dataset_path = _make_dataset_config(tmp_path)
+    run_dir = tmp_path / "runs" / "train"
+    weights_dir = run_dir / "weights"
+    weights_dir.mkdir(parents=True)
+    last_path = weights_dir / "last.pt"
+    last_path.write_bytes(b"last")
+    _install_fake_yoloe(
+        monkeypatch,
+        trainer=SimpleNamespace(save_dir=run_dir, best=weights_dir / "missing_best.pt", last=last_path),
+    )
+
+    result = train_model("model.pt", dataset_path)
+
+    assert result.checkpoint_path == last_path.resolve()
+    assert result.metrics_path is None
+
+
+def test_train_model_falls_back_to_default_checkpoint_paths(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    dataset_path = _make_dataset_config(tmp_path)
+    run_dir = tmp_path / "runs" / "train"
+    weights_dir = run_dir / "weights"
+    weights_dir.mkdir(parents=True)
+    best_path = weights_dir / "best.pt"
+    best_path.write_bytes(b"best")
+    _install_fake_yoloe(monkeypatch, trainer=SimpleNamespace(save_dir=run_dir, best=None, last=None))
+
+    result = train_model("model.pt", dataset_path)
+
+    assert result.checkpoint_path == best_path.resolve()
+
+
+def test_train_model_resolves_relative_trainer_checkpoint_paths(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    dataset_path = _make_dataset_config(tmp_path)
+    run_dir = tmp_path / "runs" / "train"
+    weights_dir = run_dir / "weights"
+    weights_dir.mkdir(parents=True)
+    best_path = weights_dir / "best.pt"
+    best_path.write_bytes(b"best")
+    _install_fake_yoloe(monkeypatch, trainer=SimpleNamespace(save_dir=run_dir, best="weights/best.pt", last=None))
+
+    result = train_model("model.pt", dataset_path)
+
+    assert result.checkpoint_path == best_path.resolve()
+
+
+def test_train_model_expands_user_model_checkpoint_path(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    dataset_path = _make_dataset_config(tmp_path)
+    run_dir = tmp_path / "runs" / "train"
+    weights_dir = run_dir / "weights"
+    weights_dir.mkdir(parents=True)
+    (weights_dir / "best.pt").write_bytes(b"best")
+    fake_yoloe = _install_fake_yoloe(
+        monkeypatch,
+        trainer=SimpleNamespace(save_dir=run_dir, best=weights_dir / "best.pt", last=weights_dir / "last.pt"),
+    )
+
+    train_model("~/models/yoloe.pt", dataset_path)
+
+    assert fake_yoloe.instances[0].model == str(Path("~/models/yoloe.pt").expanduser())
+
+
+def test_train_model_preserves_url_model_checkpoint(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    dataset_path = _make_dataset_config(tmp_path)
+    run_dir = tmp_path / "runs" / "train"
+    weights_dir = run_dir / "weights"
+    weights_dir.mkdir(parents=True)
+    (weights_dir / "best.pt").write_bytes(b"best")
+    fake_yoloe = _install_fake_yoloe(
+        monkeypatch,
+        trainer=SimpleNamespace(save_dir=run_dir, best=weights_dir / "best.pt", last=weights_dir / "last.pt"),
+    )
+
+    checkpoint_url = "https://example.com/models/yoloe.pt"
+    train_model(checkpoint_url, dataset_path)
+
+    assert fake_yoloe.instances[0].model == checkpoint_url
+
+
+def test_train_model_raises_when_checkpoint_is_missing(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    dataset_path = _make_dataset_config(tmp_path)
+    run_dir = tmp_path / "runs" / "train"
+    run_dir.mkdir(parents=True)
+    _install_fake_yoloe(monkeypatch, trainer=SimpleNamespace(save_dir=run_dir, best=None, last=None))
+
+    with pytest.raises(TrainingError, match="Could not find a trained checkpoint"):
+        train_model("model.pt", dataset_path)
+
+
+def test_train_model_raises_when_trainer_is_missing(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    dataset_path = _make_dataset_config(tmp_path)
+    _install_fake_yoloe(monkeypatch, trainer=None)
+
+    with pytest.raises(TrainingError, match="did not expose a trainer"):
+        train_model("model.pt", dataset_path)
+
+
+def test_train_model_can_skip_dataset_validation(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    dataset_path = tmp_path / "data.yaml"
+    run_dir = tmp_path / "runs" / "train"
+    weights_dir = run_dir / "weights"
+    weights_dir.mkdir(parents=True)
+    (weights_dir / "best.pt").write_bytes(b"best")
+    fake_yoloe = _install_fake_yoloe(
+        monkeypatch,
+        trainer=SimpleNamespace(save_dir=run_dir, best=weights_dir / "best.pt", last=weights_dir / "last.pt"),
+    )
+    monkeypatch.setattr(
+        training,
+        "validate_dataset_config",
+        lambda *_args, **_kwargs: pytest.fail("dataset validation should have been skipped"),
+    )
+
+    result = train_model("model.pt", dataset_path, validate_dataset=False)
+
+    assert result.metadata["dataset"] is None
+    assert fake_yoloe.instances[0].train_kwargs["data"] == str(dataset_path)
+
+
+def test_train_model_rejects_mapping_dataset_config() -> None:
+    with pytest.raises(ValueError, match="requires dataset_config to be a YAML/config path"):
+        train_model("model.pt", {"train": "images/train"})  # type: ignore[arg-type]
+
+
+def test_train_model_rejects_empty_model_checkpoint() -> None:
+    with pytest.raises(ValueError, match="model_checkpoint to be non-empty"):
+        train_model("", "data.yaml")
+
+
+def test_train_model_rejects_empty_dataset_config_path() -> None:
+    with pytest.raises(ValueError, match="non-empty YAML/config path"):
+        train_model("model.pt", "")
+
+
+def test_train_model_rejects_unsupported_task_when_validation_is_disabled(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="Unsupported training task"):
+        train_model("model.pt", tmp_path / "data.yaml", task="pose", validate_dataset=False)  # type: ignore[arg-type]
+
+
+def test_training_symbols_are_exported_lazily() -> None:
+    assert yoloe_tensorrt.train_model is train_model
+    assert yoloe_tensorrt.TrainingResult is TrainingResult
+    assert yoloe_tensorrt.TrainingError is TrainingError
+    assert "train_model" in dir(yoloe_tensorrt)

--- a/yoloe_tensorrt/__init__.py
+++ b/yoloe_tensorrt/__init__.py
@@ -9,6 +9,9 @@ __all__ = [
     "DatasetSplit",
     "DatasetValidationError",
     "export_model",
+    "train_model",
+    "TrainingError",
+    "TrainingResult",
     "validate_dataset_config",
     "configure_logging",
     "GStreamerSource",
@@ -58,6 +61,18 @@ def __getattr__(name: str):
         from .datasets import validate_dataset_config
 
         return validate_dataset_config
+    if name == "train_model":
+        from .training import train_model
+
+        return train_model
+    if name == "TrainingError":
+        from .training import TrainingError
+
+        return TrainingError
+    if name == "TrainingResult":
+        from .training import TrainingResult
+
+        return TrainingResult
     if name == "configure_logging":
         from .logging_utils import configure_logging
 

--- a/yoloe_tensorrt/training.py
+++ b/yoloe_tensorrt/training.py
@@ -1,0 +1,242 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+from .datasets import DatasetConfig, DatasetTask, validate_dataset_config
+
+_CONFLICTING_OVERRIDE_KEYS = frozenset(
+    {
+        "batch",
+        "data",
+        "device",
+        "epochs",
+        "exist_ok",
+        "imgsz",
+        "mode",
+        "model",
+        "name",
+        "project",
+        "task",
+    }
+)
+_METRICS_FILENAMES = ("results.csv", "results.json", "metrics.json")
+_SUPPORTED_TRAINING_TASKS = {"detect", "segment"}
+
+
+class TrainingError(RuntimeError):
+    """Raised when Ultralytics training completes without expected run artifacts."""
+
+
+@dataclass(frozen=True)
+class TrainingResult:
+    checkpoint_path: Path
+    run_dir: Path
+    metrics_path: Path | None
+    metadata: dict[str, Any]
+
+
+def train_model(
+    model_checkpoint: str | Path,
+    dataset_config: str | Path,
+    *,
+    task: DatasetTask = "detect",
+    imgsz: int | tuple[int, int] = 640,
+    epochs: int = 100,
+    batch: int | float | str = 16,
+    device: Any = None,
+    output_dir: str | Path = "outputs/training",
+    name: str | None = None,
+    overrides: Mapping[str, Any] | None = None,
+    validate_dataset: bool = True,
+    exist_ok: bool = False,
+) -> TrainingResult:
+    """Train or fine-tune a YOLOE checkpoint through Ultralytics and return run artifacts."""
+
+    if task not in _SUPPORTED_TRAINING_TASKS:
+        raise ValueError(f"Unsupported training task {task!r}; expected 'detect' or 'segment'.")
+
+    model_path = _normalize_model_checkpoint(model_checkpoint)
+    dataset_path = _normalize_dataset_config_path(dataset_config)
+    output_path = Path(output_dir).expanduser()
+    trainer_overrides = _normalize_overrides(overrides)
+    dataset = validate_dataset_config(dataset_path, task=task) if validate_dataset else None
+
+    train_kwargs: dict[str, Any] = {
+        "data": str(dataset_path),
+        "task": task,
+        "imgsz": imgsz,
+        "epochs": epochs,
+        "batch": batch,
+        "project": str(output_path),
+        "exist_ok": exist_ok,
+        **trainer_overrides,
+    }
+    if device is not None:
+        train_kwargs["device"] = device
+    if name is not None:
+        train_kwargs["name"] = name
+
+    yoloe_cls = _load_yoloe_class()
+    model = yoloe_cls(model_path, task=task)
+    metrics = model.train(**train_kwargs)
+    trainer = getattr(model, "trainer", None)
+    if trainer is None:
+        raise TrainingError("Ultralytics training did not expose a trainer with run artifacts.")
+
+    run_dir = _resolve_run_dir(trainer)
+    checkpoint_path = _resolve_checkpoint_path(trainer, run_dir)
+    metrics_path = _resolve_metrics_path(run_dir)
+    metadata = _build_training_metadata(
+        model_checkpoint=model_path,
+        dataset_path=dataset_path,
+        dataset=dataset,
+        task=task,
+        imgsz=imgsz,
+        epochs=epochs,
+        batch=batch,
+        device=device,
+        output_path=output_path,
+        name=name,
+        exist_ok=exist_ok,
+        overrides=trainer_overrides,
+        metrics=metrics,
+    )
+
+    return TrainingResult(
+        checkpoint_path=checkpoint_path,
+        run_dir=run_dir,
+        metrics_path=metrics_path,
+        metadata=metadata,
+    )
+
+
+def _load_yoloe_class() -> Any:
+    from ultralytics import YOLOE
+
+    return YOLOE
+
+
+def _normalize_model_checkpoint(model_checkpoint: str | Path) -> str:
+    if not isinstance(model_checkpoint, str | Path):
+        raise ValueError("train_model(...) requires model_checkpoint to be a checkpoint path or asset name.")
+    raw_value = str(model_checkpoint).strip()
+    if not raw_value:
+        raise ValueError("train_model(...) requires model_checkpoint to be non-empty.")
+    if isinstance(model_checkpoint, str) and "://" in raw_value:
+        return raw_value
+    return str(Path(raw_value).expanduser())
+
+
+def _normalize_dataset_config_path(dataset_config: str | Path) -> Path:
+    if not isinstance(dataset_config, str | Path):
+        raise ValueError("train_model(...) requires dataset_config to be a YAML/config path.")
+    if not str(dataset_config).strip():
+        raise ValueError("train_model(...) requires dataset_config to be a non-empty YAML/config path.")
+    return Path(dataset_config).expanduser()
+
+
+def _normalize_overrides(overrides: Mapping[str, Any] | None) -> dict[str, Any]:
+    if overrides is None:
+        return {}
+    if not isinstance(overrides, Mapping):
+        raise ValueError("train_model(...) overrides must be a mapping when provided.")
+
+    invalid_keys = sorted(repr(key) for key in overrides if not isinstance(key, str) or not key)
+    if invalid_keys:
+        joined = ", ".join(invalid_keys)
+        raise ValueError(f"Ultralytics override key(s) must be non-empty strings: {joined}")
+
+    if "save" in overrides and not overrides["save"]:
+        raise ValueError(
+            "train_model(...) requires Ultralytics to save checkpoints; call Ultralytics directly for save=False runs."
+        )
+
+    conflicting = sorted(key for key in overrides if key in _CONFLICTING_OVERRIDE_KEYS)
+    if conflicting:
+        joined = ", ".join(conflicting)
+        raise ValueError(f"Ultralytics override key(s) conflict with train_model(...) arguments: {joined}")
+    return dict(overrides)
+
+
+def _resolve_run_dir(trainer: Any) -> Path:
+    raw_save_dir = getattr(trainer, "save_dir", None)
+    if raw_save_dir is None:
+        raise TrainingError("Ultralytics trainer did not expose a save_dir.")
+    return Path(raw_save_dir).expanduser().resolve(strict=False)
+
+
+def _resolve_checkpoint_path(trainer: Any, run_dir: Path) -> Path:
+    for attr in ("best", "last"):
+        path = _optional_path(getattr(trainer, attr, None), base_dir=run_dir)
+        if path is not None and path.exists():
+            return path.resolve()
+
+    for candidate in (run_dir / "weights" / "best.pt", run_dir / "weights" / "last.pt"):
+        if candidate.exists():
+            return candidate.resolve()
+
+    raise TrainingError(f"Could not find a trained checkpoint under Ultralytics run directory: {run_dir}")
+
+
+def _resolve_metrics_path(run_dir: Path) -> Path | None:
+    for filename in _METRICS_FILENAMES:
+        path = run_dir / filename
+        if path.exists():
+            return path.resolve()
+    return None
+
+
+def _optional_path(value: Any, *, base_dir: Path) -> Path | None:
+    if value is None or value is False or value == "":
+        return None
+    path = Path(value).expanduser()
+    if not path.is_absolute():
+        path = base_dir / path
+    return path.resolve(strict=False)
+
+
+def _build_training_metadata(
+    *,
+    model_checkpoint: str,
+    dataset_path: Path,
+    dataset: DatasetConfig | None,
+    task: DatasetTask,
+    imgsz: int | tuple[int, int],
+    epochs: int,
+    batch: int | float | str,
+    device: Any,
+    output_path: Path,
+    name: str | None,
+    exist_ok: bool,
+    overrides: Mapping[str, Any],
+    metrics: Any,
+) -> dict[str, Any]:
+    return {
+        "model_checkpoint": model_checkpoint,
+        "dataset_config": str(dataset_path),
+        "dataset": _dataset_metadata(dataset),
+        "task": task,
+        "imgsz": imgsz,
+        "epochs": epochs,
+        "batch": batch,
+        "device": device,
+        "output_dir": str(output_path),
+        "name": name,
+        "exist_ok": exist_ok,
+        "overrides": dict(overrides),
+        "metrics_type": None if metrics is None else type(metrics).__name__,
+    }
+
+
+def _dataset_metadata(dataset: DatasetConfig | None) -> dict[str, Any] | None:
+    if dataset is None:
+        return None
+    return {
+        "root": str(dataset.root),
+        "names": dict(dataset.names),
+        "train_image_count": dataset.train.image_count,
+        "val_image_count": dataset.val.image_count,
+        "test_image_count": None if dataset.test is None else dataset.test.image_count,
+    }


### PR DESCRIPTION
  - Added public train_model(...) API for YOLOE training and fine-tuning through Ultralytics.
  - Added TrainingResult and TrainingError result/error types.
  - Reused dataset config validation by default before launching training.
  - Added structured result extraction for trained checkpoint path, Ultralytics run directory, optional metrics path, and training metadata.
  - Added safe handling for local checkpoint paths, ~ expansion, URL checkpoint strings, and relative trainer checkpoint paths.
  - Added validation for unsupported tasks, invalid dataset config inputs, invalid override keys, conflicting override keys, and no-checkpoint save=False style runs.
  - Documented the training workflow, output location, dataset validation behavior, and Ultralytics override usage.
  - Added mocked training unit tests so the suite validates API behavior without running a real Ultralytics training job.