### PR TITLE
feat: added fine-tuning and training cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Added a `yoloe-train` CLI and `python -m yoloe_tensorrt train` entrypoint for YOLOE training and fine-tuning.
 - Added a package-level `train_model(...)` API for YOLOE training and fine-tuning through Ultralytics.
 - Added YOLOE dataset config validation helpers for Ultralytics-style detection and segmentation training inputs.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,6 +25,7 @@ the main inference hot path into a native backend.
 - `yoloe-export`
 - `yoloe-camera-gui`
 - `yoloe-benchmark`
+- `yoloe-train`
 - `train_model(...)`
 - `validate_dataset_config(...)`
 - `python -m yoloe_tensorrt`

--- a/docs/training.md
+++ b/docs/training.md
@@ -5,6 +5,53 @@ validates dataset configs before launching a run.
 
 ## Train or fine-tune
 
+Use `yoloe-train` for command-line training:
+
+```bash
+yoloe-train yoloe-26s-seg.pt data.yaml \
+  --task segment \
+  --imgsz 640 \
+  --epochs 50 \
+  --batch 8 \
+  --device cuda:0 \
+  --output-dir outputs/training \
+  --name seg-run
+```
+
+The same command is available through the module entry point:
+
+```bash
+python -m yoloe_tensorrt train yoloe-26s-seg.pt data.yaml --task segment
+```
+
+On success, the CLI prints the trained checkpoint and run directory. It also prints the metrics file when Ultralytics
+created one:
+
+```text
+checkpoint: outputs/training/seg-run/weights/best.pt
+run_dir: outputs/training/seg-run
+metrics: outputs/training/seg-run/results.csv
+```
+
+Resume an interrupted run with `--resume`, or pass a specific checkpoint:
+
+```bash
+yoloe-train yoloe-26s-seg.pt data.yaml --resume
+yoloe-train yoloe-26s-seg.pt data.yaml --resume-checkpoint outputs/training/seg-run/weights/last.pt
+```
+
+Pass advanced Ultralytics trainer options with repeatable `--ultralytics-arg KEY=VALUE` entries. Values are parsed as
+YAML:
+
+```bash
+yoloe-train yoloe-26s-seg.pt data.yaml \
+  --ultralytics-arg workers=4 \
+  --ultralytics-arg optimizer=AdamW \
+  --ultralytics-arg lr0=0.001
+```
+
+By default, CLI run outputs are placed under `outputs/training`.
+
 Use `train_model(...)` when you want the package to validate the dataset and call Ultralytics for you:
 
 ```python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,7 @@ all = [
 yoloe-camera-gui = "yoloe_tensorrt.gui:main"
 yoloe-export = "yoloe_tensorrt.export_cli:main"
 yoloe-benchmark = "yoloe_tensorrt.benchmark_cli:main"
+yoloe-train = "yoloe_tensorrt.train_cli:main"
 
 [tool.scikit-build]
 cmake.build-type = "Release"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -37,6 +37,7 @@ def test_module_entrypoint_displays_help() -> None:
     assert "camera-gui" in result.stdout
     assert "export" in result.stdout
     assert "benchmark" in result.stdout
+    assert "train" in result.stdout
 
 
 def test_export_cli_displays_help() -> None:

--- a/tests/test_dependency_metadata.py
+++ b/tests/test_dependency_metadata.py
@@ -34,6 +34,12 @@ def test_export_and_dev_dependencies_include_onnxscript() -> None:
     assert "mkdocs>=1.6" in all_reqs
 
 
+def test_project_scripts_include_training_cli() -> None:
+    data = _load_pyproject()
+
+    assert data["project"]["scripts"]["yoloe-train"] == "yoloe_tensorrt.train_cli:main"
+
+
 def test_requirements_files_include_clip_dependency() -> None:
     requirements = (REPO_ROOT / "requirements.txt").read_text(encoding="utf-8")
     requirements_dev = (REPO_ROOT / "requirements-dev.txt").read_text(encoding="utf-8")

--- a/tests/test_train_cli.py
+++ b/tests/test_train_cli.py
@@ -1,0 +1,246 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+from yoloe_tensorrt import train_cli
+from yoloe_tensorrt.datasets import DatasetValidationError
+from yoloe_tensorrt.training import TrainingError, TrainingResult
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def test_train_cli_displays_help() -> None:
+    result = subprocess.run(
+        [sys.executable, "-m", "yoloe_tensorrt", "train", "--help"],
+        check=False,
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+    )
+
+    assert result.returncode == 0
+    assert "Train or fine-tune a YOLOE checkpoint through Ultralytics." in result.stdout
+    assert "--imgsz" in result.stdout
+    assert "--epochs" in result.stdout
+    assert "--batch" in result.stdout
+    assert "--resume" in result.stdout
+    assert "--resume-checkpoint" in result.stdout
+    assert "--ultralytics-arg" in result.stdout
+
+
+def test_train_cli_passes_core_args_and_prints_result(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    calls: list[dict[str, Any]] = []
+    checkpoint = tmp_path / "runs" / "seg" / "weights" / "best.pt"
+    run_dir = checkpoint.parent.parent
+    metrics = run_dir / "results.csv"
+
+    def _fake_train_model(model_checkpoint: str, dataset_config: Path, **kwargs: Any) -> TrainingResult:
+        calls.append(
+            {
+                "model_checkpoint": model_checkpoint,
+                "dataset_config": dataset_config,
+                **kwargs,
+            }
+        )
+        return TrainingResult(
+            checkpoint_path=checkpoint,
+            run_dir=run_dir,
+            metrics_path=metrics,
+            metadata={},
+        )
+
+    monkeypatch.setattr(train_cli, "train_model", _fake_train_model)
+
+    exit_code = train_cli.main(
+        [
+            "yoloe-26s-seg.pt",
+            "data.yaml",
+            "--task",
+            "segment",
+            "--imgsz",
+            "320x480",
+            "--epochs",
+            "3",
+            "--batch",
+            "0.5",
+            "--device",
+            "cuda:0",
+            "--output-dir",
+            str(tmp_path / "outputs" / "training"),
+            "--name",
+            "seg-run",
+            "--resume",
+            "--exist-ok",
+            "--no-validate-dataset",
+            "--ultralytics-arg",
+            "workers=2",
+            "--ultralytics-arg",
+            "amp=false",
+        ]
+    )
+
+    output = capsys.readouterr().out
+    assert exit_code == 0
+    assert output == f"checkpoint: {checkpoint}\nrun_dir: {run_dir}\nmetrics: {metrics}\n"
+    assert calls == [
+        {
+            "model_checkpoint": "yoloe-26s-seg.pt",
+            "dataset_config": Path("data.yaml"),
+            "task": "segment",
+            "imgsz": (320, 480),
+            "epochs": 3,
+            "batch": 0.5,
+            "device": "cuda:0",
+            "output_dir": tmp_path / "outputs" / "training",
+            "name": "seg-run",
+            "overrides": {"workers": 2, "amp": False, "resume": True},
+            "validate_dataset": False,
+            "exist_ok": True,
+        }
+    ]
+
+
+def test_train_cli_passes_resume_checkpoint(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    calls: list[dict[str, Any]] = []
+
+    def _fake_train_model(model_checkpoint: str, dataset_config: Path, **kwargs: Any) -> TrainingResult:
+        calls.append(kwargs)
+        return TrainingResult(
+            checkpoint_path=tmp_path / "best.pt",
+            run_dir=tmp_path / "run",
+            metrics_path=None,
+            metadata={},
+        )
+
+    monkeypatch.setattr(train_cli, "train_model", _fake_train_model)
+
+    exit_code = train_cli.main(["model.pt", "data.yaml", "--resume-checkpoint", "runs/train/weights/last.pt"])
+
+    assert exit_code == 0
+    assert calls[0]["overrides"]["resume"] == "runs/train/weights/last.pt"
+
+
+def test_train_cli_allows_options_before_positionals(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    calls: list[dict[str, Any]] = []
+
+    def _fake_train_model(model_checkpoint: str, dataset_config: Path, **kwargs: Any) -> TrainingResult:
+        calls.append(
+            {
+                "model_checkpoint": model_checkpoint,
+                "dataset_config": dataset_config,
+                **kwargs,
+            }
+        )
+        return TrainingResult(
+            checkpoint_path=tmp_path / "best.pt",
+            run_dir=tmp_path / "run",
+            metrics_path=None,
+            metadata={},
+        )
+
+    monkeypatch.setattr(train_cli, "train_model", _fake_train_model)
+
+    exit_code = train_cli.main(["--imgsz", "640", "--resume", "model.pt", "data.yaml"])
+
+    assert exit_code == 0
+    assert calls[0]["model_checkpoint"] == "model.pt"
+    assert calls[0]["dataset_config"] == Path("data.yaml")
+    assert calls[0]["imgsz"] == 640
+    assert calls[0]["overrides"]["resume"] is True
+
+
+def test_train_cli_omits_metrics_when_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    def _fake_train_model(*_args: Any, **_kwargs: Any) -> TrainingResult:
+        return TrainingResult(
+            checkpoint_path=tmp_path / "best.pt",
+            run_dir=tmp_path / "run",
+            metrics_path=None,
+            metadata={},
+        )
+
+    monkeypatch.setattr(train_cli, "train_model", _fake_train_model)
+
+    exit_code = train_cli.main(["model.pt", "data.yaml"])
+
+    output = capsys.readouterr().out
+    assert exit_code == 0
+    assert output == f"checkpoint: {tmp_path / 'best.pt'}\nrun_dir: {tmp_path / 'run'}\n"
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        ["model.pt", "data.yaml", "--ultralytics-arg", "workers"],
+        ["model.pt", "data.yaml", "--ultralytics-arg", "=2"],
+        ["model.pt", "data.yaml", "--ultralytics-arg", "workers=2", "--ultralytics-arg", "workers=4"],
+        ["model.pt", "data.yaml", "--resume", "--ultralytics-arg", "resume=true"],
+        ["model.pt", "data.yaml", "--resume", "--resume-checkpoint", "runs/train/weights/last.pt"],
+        ["model.pt", "data.yaml", "--ultralytics-arg", "workers=["],
+        ["model.pt", "data.yaml", "--imgsz", "320x"],
+        ["model.pt", "data.yaml", "--imgsz", "320", "480", "640"],
+    ],
+)
+def test_train_cli_rejects_invalid_cli_args(
+    monkeypatch: pytest.MonkeyPatch,
+    args: list[str],
+) -> None:
+    monkeypatch.setattr(train_cli, "train_model", lambda *_args, **_kwargs: pytest.fail("should not train"))
+
+    with pytest.raises(SystemExit) as exc_info:
+        train_cli.main(args)
+
+    assert exc_info.value.code == 2
+
+
+@pytest.mark.parametrize(
+    ("exception", "message"),
+    [
+        (DatasetValidationError("bad dataset"), "error: bad dataset"),
+        (TrainingError("missing checkpoint"), "error: missing checkpoint"),
+        (ValueError("bad override"), "error: bad override"),
+    ],
+)
+def test_train_cli_reports_actionable_training_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    exception: Exception,
+    message: str,
+) -> None:
+    def _fake_train_model(*_args: Any, **_kwargs: Any) -> TrainingResult:
+        raise exception
+
+    monkeypatch.setattr(train_cli, "train_model", _fake_train_model)
+
+    exit_code = train_cli.main(["model.pt", "data.yaml"])
+
+    assert exit_code == 1
+    assert message in capsys.readouterr().err
+
+
+def test_train_cli_reports_unavailable_training_dependencies(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    def _fake_train_model(*_args: Any, **_kwargs: Any) -> TrainingResult:
+        raise ModuleNotFoundError("No module named 'ultralytics'")
+
+    monkeypatch.setattr(train_cli, "train_model", _fake_train_model)
+
+    exit_code = train_cli.main(["model.pt", "data.yaml"])
+
+    assert exit_code == 1
+    error_output = capsys.readouterr().err
+    assert "training dependencies are unavailable" in error_output
+    assert "ultralytics" in error_output

--- a/yoloe_tensorrt/__main__.py
+++ b/yoloe_tensorrt/__main__.py
@@ -21,6 +21,9 @@ def build_arg_parser() -> argparse.ArgumentParser:
 
     benchmark_parser = subparsers.add_parser("benchmark", help="Benchmark runtime performance.")
     benchmark_parser.set_defaults(handler="benchmark")
+
+    train_parser = subparsers.add_parser("train", help="Train or fine-tune a YOLOE checkpoint.")
+    train_parser.set_defaults(handler="train")
     return parser
 
 
@@ -38,6 +41,10 @@ def main(argv: list[str] | None = None) -> int:
         from .benchmark_cli import main as benchmark_main
 
         return benchmark_main(argv[1:])
+    if argv[:1] == ["train"]:
+        from .train_cli import main as train_main
+
+        return train_main(argv[1:])
 
     parser = build_arg_parser()
     parser.parse_args(argv)

--- a/yoloe_tensorrt/train_cli.py
+++ b/yoloe_tensorrt/train_cli.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from .datasets import DatasetValidationError
+from .logging_utils import configure_logging
+from .training import TrainingError, TrainingResult, train_model
+
+
+class _CliArgumentError(ValueError):
+    pass
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Train or fine-tune a YOLOE checkpoint through Ultralytics.")
+    parser.add_argument("model", help="Local checkpoint path, URL, or downloadable asset name.")
+    parser.add_argument("data", help="Ultralytics-compatible dataset YAML/config path.")
+    parser.add_argument("--task", choices=("detect", "segment"), default="detect", help="Training task.")
+    parser.add_argument(
+        "--imgsz",
+        type=_parse_imgsz,
+        default=640,
+        metavar="N|HxW",
+        help="Image size. Use one value for square training or HxW/H,W for rectangular training. Defaults to 640.",
+    )
+    parser.add_argument("--epochs", type=int, default=100, help="Number of training epochs. Defaults to 100.")
+    parser.add_argument(
+        "--batch",
+        type=_parse_batch,
+        default=16,
+        help="Batch size. YAML scalars are accepted, for example 16, 0.5, or auto. Defaults to 16.",
+    )
+    parser.add_argument("--device", default=None, help="Training device, for example cuda:0, 0, or cpu.")
+    parser.add_argument("--output-dir", default="outputs/training", help="Directory for Ultralytics runs.")
+    parser.add_argument("--name", default=None, help="Ultralytics run name.")
+    parser.add_argument("--exist-ok", action="store_true", help="Allow Ultralytics to reuse an existing run name.")
+    parser.add_argument(
+        "--resume",
+        action="store_true",
+        help="Resume training with Ultralytics resume=True.",
+    )
+    parser.add_argument(
+        "--resume-checkpoint",
+        "--resume-from",
+        dest="resume_checkpoint",
+        default=None,
+        metavar="CHECKPOINT",
+        help="Resume training from a specific checkpoint path.",
+    )
+    parser.add_argument(
+        "--ultralytics-arg",
+        action="append",
+        default=None,
+        metavar="KEY=VALUE",
+        help="Extra Ultralytics trainer override. Repeat for multiple args; values are parsed as YAML.",
+    )
+    parser.add_argument(
+        "--no-validate-dataset",
+        action="store_false",
+        dest="validate_dataset",
+        help="Skip yoloe-tensorrt dataset validation before launching Ultralytics.",
+    )
+    parser.set_defaults(validate_dataset=True)
+    parser.add_argument("--log-level", default="INFO", help="Logging level for the training command.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_arg_parser()
+    args = parser.parse_args(argv)
+    configure_logging(level=args.log_level, include_timestamps=True)
+
+    try:
+        overrides = _parse_ultralytics_args(args.ultralytics_arg)
+        if args.resume and args.resume_checkpoint is not None:
+            raise _CliArgumentError("--resume cannot be combined with --resume-checkpoint.")
+        if args.resume or args.resume_checkpoint is not None:
+            if "resume" in overrides:
+                raise _CliArgumentError("--resume cannot be combined with --ultralytics-arg resume=...")
+            overrides["resume"] = args.resume_checkpoint if args.resume_checkpoint is not None else True
+    except _CliArgumentError as exc:
+        parser.error(str(exc))
+
+    try:
+        result = train_model(
+            args.model,
+            Path(args.data),
+            task=args.task,
+            imgsz=args.imgsz,
+            epochs=int(args.epochs),
+            batch=args.batch,
+            device=args.device,
+            output_dir=Path(args.output_dir),
+            name=args.name,
+            overrides=overrides,
+            validate_dataset=bool(args.validate_dataset),
+            exist_ok=bool(args.exist_ok),
+        )
+    except ImportError as exc:
+        print(
+            "error: training dependencies are unavailable. Ensure ultralytics and torch are installed "
+            f"for training: {exc}",
+            file=sys.stderr,
+        )
+        return 1
+    except (DatasetValidationError, TrainingError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    _print_result(result)
+    return 0
+
+
+def _parse_batch(value: str) -> int | float | str:
+    parsed = _load_yaml_value(value)
+    if isinstance(parsed, bool) or parsed is None or isinstance(parsed, list | dict):
+        raise argparse.ArgumentTypeError("--batch must be an integer, float, or string such as auto.")
+    if not isinstance(parsed, int | float | str):
+        raise argparse.ArgumentTypeError("--batch must be an integer, float, or string such as auto.")
+    return parsed
+
+
+def _parse_imgsz(value: str) -> int | tuple[int, int]:
+    raw_value = value.strip().lower()
+    if not raw_value:
+        raise argparse.ArgumentTypeError("--imgsz must not be empty.")
+
+    for separator in ("x", ","):
+        if separator in raw_value:
+            parts = [part.strip() for part in raw_value.split(separator)]
+            if len(parts) != 2 or not all(parts):
+                raise argparse.ArgumentTypeError("--imgsz must be one integer or two integers as HxW or H,W.")
+            height, width = (_parse_positive_int(part, "--imgsz") for part in parts)
+            return (height, width)
+
+    return _parse_positive_int(raw_value, "--imgsz")
+
+
+def _parse_positive_int(value: str, option_name: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"{option_name} must contain integer value(s).") from exc
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError(f"{option_name} must be greater than zero.")
+    return parsed
+
+
+def _parse_ultralytics_args(entries: list[str] | None) -> dict[str, Any]:
+    overrides: dict[str, Any] = {}
+    for entry in entries or []:
+        if "=" not in entry:
+            raise _CliArgumentError("--ultralytics-arg must use KEY=VALUE syntax.")
+        key, raw_value = entry.split("=", 1)
+        key = key.strip()
+        if not key:
+            raise _CliArgumentError("--ultralytics-arg keys must not be empty.")
+        if key in overrides:
+            raise _CliArgumentError(f"--ultralytics-arg key {key!r} was provided more than once.")
+        try:
+            overrides[key] = "" if raw_value == "" else _load_yaml_value(raw_value)
+        except argparse.ArgumentTypeError as exc:
+            raise _CliArgumentError(str(exc)) from exc
+    return overrides
+
+
+def _load_yaml_value(value: str) -> Any:
+    try:
+        return yaml.safe_load(value)
+    except yaml.YAMLError as exc:
+        raise argparse.ArgumentTypeError(f"could not parse YAML scalar {value!r}: {exc}") from exc
+
+
+def _print_result(result: TrainingResult) -> None:
+    print(f"checkpoint: {result.checkpoint_path}")
+    print(f"run_dir: {result.run_dir}")
+    if result.metrics_path is not None:
+        print(f"metrics: {result.metrics_path}")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())


### PR DESCRIPTION
  - Added yoloe-train console script for YOLOE training and fine-tuning.
  - Added python -m yoloe_tensorrt train ... module entrypoint.
  - Added CLI options for task, image size, epochs, batch, device, output directory, run name, resume, dataset validation, and extra Ultralytics overrides.
  - Added validation for ambiguous or invalid CLI argument combinations.
  - Added tests covering CLI help, argument forwarding, resume behavior, error handling, package script metadata, and module entrypoint help.
  - Updated training docs, README-style docs index, and changelog with the new CLI surface.