### PR TITLE
feat: added post-training TensorRT artifact export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Added a `yoloe-train` CLI and `python -m yoloe_tensorrt train` entrypoint for YOLOE training and fine-tuning.
 - Added a package-level `train_model(...)` API for YOLOE training and fine-tuning through Ultralytics.
+- Added optional training-to-export integration so `train_model(...)` and `yoloe-train` can export the best or last fine-tuned checkpoint into a TensorRT artifact bundle.
 - Added YOLOE dataset config validation helpers for Ultralytics-style detection and segmentation training inputs.
 
 ## 0.2.0

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # yoloe-tensorrt
 
-`yoloe-tensorrt` is a Jetson-first TensorRT runtime for Ultralytics YOLOE models with runtime-custom text labels and visual prompts. It exposes a normal Python package API, ships a native C++ TensorRT backend for the main inference hot path, and includes a live camera GUI for interactive testing.
+`yoloe-tensorrt` is a Jetson-first TensorRT runtime for Ultralytics YOLOE models with runtime-custom text labels and visual prompts. It exposes a normal Python package API, ships a native C++ TensorRT backend for the main inference hot path, includes a live camera GUI for interactive testing, and can export fine-tuned checkpoints directly into TensorRT artifact bundles.
 
 ## Highlights
 
@@ -11,7 +11,7 @@
 - Unified `predict(...)` and `track(...)` APIs with a prepared-tensor fast path
 - RTSP, USB camera, and Jetson zero-copy NVMM/EGL/CUDA camera ingest support
 - Structured benchmark CLI for runtime paths, prompt updates, CPU use, allocations, and regression comparison
-- Python package API, export CLI, and live camera GUI
+- Python package API, export CLI, training CLI, and live camera GUI
 - Jetson-first deployment model with Linux x86_64 CUDA/TensorRT also supported
 
 ## Supported Environments
@@ -242,6 +242,7 @@ GitHub Actions is the supported automation path for this repository.
 - [Installation](docs/installation.md)
 - [Quickstart](docs/quickstart.md)
 - [Export and Artifact Bundles](docs/export.md)
+- [Training](docs/training.md)
 - [Runtime Prompts](docs/prompts.md)
 - [Benchmarks](docs/benchmarks.md)
 - [Camera GUI](docs/camera-gui.md)

--- a/docs/export.md
+++ b/docs/export.md
@@ -38,6 +38,9 @@ If visual prompt export is enabled, it may also contain:
 - `visual_prompt.onnx`
 - `visual_prompt.engine`
 
+`metadata.json` always stores the core runtime/export metadata. When the bundle was produced from the training flow, it
+can also include a `training_metadata` block for traceability back to the training run and selected checkpoint.
+
 ## Production guidance
 
 - Prefer prebuilt bundles and `YOLOEEngine.from_engine(...)`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@ the main inference hot path into a native backend.
 - Production use through prebuilt artifact bundles
 - Live USB, RTSP, and Jetson zero-copy camera experimentation through a bundled GUI
 - Runtime benchmark checks across input paths and prompt update costs
-- Dataset config validation before YOLOE training and fine-tuning workflows
+- Dataset config validation before YOLOE training and fine-tuning workflows, with optional post-training artifact export
 
 ## What it is not
 

--- a/docs/training.md
+++ b/docs/training.md
@@ -1,7 +1,8 @@
 # Training
 
 `yoloe-tensorrt` delegates YOLOE training and fine-tuning to Ultralytics while providing a package-level API that
-validates dataset configs before launching a run.
+validates dataset configs before launching a run and can export trained checkpoints directly into a TensorRT artifact
+bundle.
 
 ## Train or fine-tune
 
@@ -52,6 +53,40 @@ yoloe-train yoloe-26s-seg.pt data.yaml \
 
 By default, CLI run outputs are placed under `outputs/training`.
 
+## Export after training
+
+Use `--export` to send the trained checkpoint through the normal `export_model(...)` path immediately after training:
+
+```bash
+yoloe-train yoloe-26s-seg.pt data.yaml \
+  --task segment \
+  --epochs 50 \
+  --export \
+  --export-artifact-dir outputs/artifacts/seg-run \
+  --export-format onnx \
+  --export-format engine
+```
+
+Export the last checkpoint instead of the default best checkpoint:
+
+```bash
+yoloe-train yoloe-26s-seg.pt data.yaml \
+  --resume \
+  --export \
+  --export-checkpoint last
+```
+
+The training CLI mirrors the export CLI through `--export-*` flags for formats, dynamic or fixed shapes, FP16,
+visual-prompt engine generation, export image size, max detections, workspace size, ONNX exporter, opset, and
+overwrite behavior.
+
+When export runs successfully, the CLI also prints:
+
+```text
+exported_checkpoint: outputs/training/seg-run/weights/best.pt
+artifact_dir: outputs/artifacts/seg-run
+```
+
 Use `train_model(...)` when you want the package to validate the dataset and call Ultralytics for you:
 
 ```python
@@ -72,7 +107,27 @@ print(result.run_dir)
 ```
 
 By default, run outputs are placed under `outputs/training`. The result includes the selected checkpoint path, the
-Ultralytics run directory, an optional metrics file path when one exists, and basic metadata about the run.
+Ultralytics run directory, an optional metrics file path when one exists, basic metadata about the run, and optional
+artifact export results when export is enabled.
+
+Export from Python by enabling `export_artifact` and selecting either the best or last checkpoint:
+
+```python
+result = train_model(
+    "yoloe-26s-seg.pt",
+    "data.yaml",
+    export_artifact=True,
+    export_checkpoint="best",
+    export_artifact_dir="outputs/artifacts/seg-run",
+)
+
+print(result.exported_checkpoint_path)
+print(result.artifact_dir)
+```
+
+The exported artifact bundle reuses the normal prompt-capable export path, so runtime text and visual prompt support
+are preserved for fine-tuned checkpoints. The bundle metadata also stores training traceability information such as the
+training run directory, selected checkpoint, dataset config path, and core training arguments.
 
 Pass advanced Ultralytics trainer options with `overrides`:
 

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -8,6 +8,7 @@ import pytest
 import torch
 import yoloe_tensorrt.export as export_mod
 from yoloe_tensorrt import export_model
+from yoloe_tensorrt.artifacts import ArtifactMetadata
 
 
 def test_export_model_creates_expected_onnx_artifacts(tmp_path: Path, model_checkpoint: Path) -> None:
@@ -84,7 +85,7 @@ def test_export_model_resumes_partial_main_only_bundle_without_reexport(
     output_dir = export_model(
         model_checkpoint,
         artifact_dir=artifact_dir,
-        formats=("engine",),
+        formats="engine",
         dynamic=False,
         build_visual_engine=False,
         overwrite=False,
@@ -97,6 +98,42 @@ def test_export_model_resumes_partial_main_only_bundle_without_reexport(
     assert metadata["main_engine_filename"] == "main.engine"
     assert metadata["visual_onnx_filename"] is None
     assert metadata["visual_engine_filename"] is None
+
+
+def test_export_model_writes_training_metadata(tmp_path: Path, model_checkpoint: Path) -> None:
+    artifact_dir = export_model(
+        model_checkpoint,
+        artifact_dir=tmp_path / "artifacts",
+        formats=("onnx",),
+        dynamic=True,
+        training_metadata={
+            "run_dir": Path("outputs/training/seg-run"),
+            "export_checkpoint": "best",
+            "device": torch.device("cpu"),
+            "checkpoints": (Path("best.pt"), Path("last.pt")),
+        },
+    )
+
+    metadata = json.loads((artifact_dir / "metadata.json").read_text())
+    assert metadata["training_metadata"] == {
+        "run_dir": "outputs/training/seg-run",
+        "export_checkpoint": "best",
+        "device": "cpu",
+        "checkpoints": ["best.pt", "last.pt"],
+    }
+
+
+def test_artifact_metadata_from_dict_defaults_missing_training_metadata(
+    tmp_path: Path,
+    model_checkpoint: Path,
+) -> None:
+    artifact_dir = export_model(model_checkpoint, artifact_dir=tmp_path / "artifacts", formats=("onnx",), dynamic=True)
+    data = json.loads((artifact_dir / "metadata.json").read_text())
+    data.pop("training_metadata", None)
+
+    metadata = ArtifactMetadata.from_dict(data)
+
+    assert metadata.training_metadata is None
 
 
 def test_export_onnx_auto_falls_back_to_legacy_when_dynamo_fails(

--- a/tests/test_train_cli.py
+++ b/tests/test_train_cli.py
@@ -30,6 +30,9 @@ def test_train_cli_displays_help() -> None:
     assert "--resume" in result.stdout
     assert "--resume-checkpoint" in result.stdout
     assert "--ultralytics-arg" in result.stdout
+    assert "--export" in result.stdout
+    assert "--export-checkpoint" in result.stdout
+    assert "--export-format" in result.stdout
 
 
 def test_train_cli_passes_core_args_and_prints_result(
@@ -179,6 +182,105 @@ def test_train_cli_omits_metrics_when_unavailable(
     assert output == f"checkpoint: {tmp_path / 'best.pt'}\nrun_dir: {tmp_path / 'run'}\n"
 
 
+def test_train_cli_forwards_post_training_export_options_and_prints_artifact_info(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    calls: list[dict[str, Any]] = []
+    checkpoint = tmp_path / "runs" / "seg" / "weights" / "best.pt"
+    run_dir = checkpoint.parent.parent
+    artifact_dir = tmp_path / "artifacts" / "bundle"
+
+    def _fake_train_model(model_checkpoint: str, dataset_config: Path, **kwargs: Any) -> TrainingResult:
+        calls.append(
+            {
+                "model_checkpoint": model_checkpoint,
+                "dataset_config": dataset_config,
+                **kwargs,
+            }
+        )
+        return TrainingResult(
+            checkpoint_path=checkpoint,
+            run_dir=run_dir,
+            metrics_path=None,
+            metadata={},
+            best_checkpoint_path=checkpoint,
+            artifact_dir=artifact_dir,
+            exported_checkpoint_path=checkpoint,
+        )
+
+    monkeypatch.setattr(train_cli, "train_model", _fake_train_model)
+
+    exit_code = train_cli.main(
+        [
+            "model.pt",
+            "data.yaml",
+            "--export",
+            "--export-checkpoint",
+            "last",
+            "--export-artifact-dir",
+            str(tmp_path / "exports"),
+            "--export-format",
+            "onnx",
+            "--export-format",
+            "engine",
+            "--export-fixed",
+            "--export-no-visual-engine",
+            "--export-no-fp16",
+            "--export-imgsz",
+            "320",
+            "--export-max-det",
+            "17",
+            "--export-workspace-mb",
+            "64",
+            "--export-exporter",
+            "legacy",
+            "--export-opset-version",
+            "17",
+            "--export-overwrite",
+        ]
+    )
+
+    output = capsys.readouterr().out
+    assert exit_code == 0
+    assert output == (
+        f"checkpoint: {checkpoint}\n"
+        f"run_dir: {run_dir}\n"
+        f"exported_checkpoint: {checkpoint}\n"
+        f"artifact_dir: {artifact_dir}\n"
+    )
+    assert calls == [
+        {
+            "model_checkpoint": "model.pt",
+            "dataset_config": Path("data.yaml"),
+            "task": "detect",
+            "imgsz": 640,
+            "epochs": 100,
+            "batch": 16,
+            "device": None,
+            "output_dir": Path("outputs/training"),
+            "name": None,
+            "overrides": {},
+            "validate_dataset": True,
+            "exist_ok": False,
+            "export_artifact": True,
+            "export_checkpoint": "last",
+            "export_artifact_dir": tmp_path / "exports",
+            "export_formats": ("onnx", "engine"),
+            "export_dynamic": False,
+            "export_build_visual_engine": False,
+            "export_fp16": False,
+            "export_imgsz": 320,
+            "export_max_det": 17,
+            "export_overwrite": True,
+            "export_workspace_bytes": 64 << 20,
+            "export_onnx_exporter": "legacy",
+            "export_onnx_opset_version": 17,
+        }
+    ]
+
+
 @pytest.mark.parametrize(
     "args",
     [
@@ -190,6 +292,7 @@ def test_train_cli_omits_metrics_when_unavailable(
         ["model.pt", "data.yaml", "--ultralytics-arg", "workers=["],
         ["model.pt", "data.yaml", "--imgsz", "320x"],
         ["model.pt", "data.yaml", "--imgsz", "320", "480", "640"],
+        ["model.pt", "data.yaml", "--export-format", "engine"],
     ],
 )
 def test_train_cli_rejects_invalid_cli_args(

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -7,6 +7,7 @@ from typing import Any
 import pytest
 import yaml
 import yoloe_tensorrt
+import yoloe_tensorrt.export as export_mod
 from yoloe_tensorrt import TrainingError, TrainingResult, train_model, training
 from yoloe_tensorrt.datasets import DatasetConfig, DatasetSplit
 
@@ -135,6 +136,10 @@ def test_train_model_validates_dataset_and_calls_ultralytics(monkeypatch: pytest
     assert result.checkpoint_path == best_path.resolve()
     assert result.run_dir == run_dir.resolve()
     assert result.metrics_path == metrics_path.resolve()
+    assert result.best_checkpoint_path == best_path.resolve()
+    assert result.last_checkpoint_path == last_path.resolve()
+    assert result.artifact_dir is None
+    assert result.exported_checkpoint_path is None
     assert result.metadata["dataset"] == {
         "root": str(tmp_path / "dataset"),
         "names": {0: "person"},
@@ -183,6 +188,158 @@ def test_train_model_merges_non_conflicting_ultralytics_overrides(
     assert fake_yoloe.instances[0].train_kwargs["workers"] == 2
     assert fake_yoloe.instances[0].train_kwargs["optimizer"] == "AdamW"
     assert fake_yoloe.instances[0].train_kwargs["lr0"] == 0.001
+
+
+def test_train_model_can_export_best_checkpoint_with_traceability(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    dataset_path = _make_dataset_config(tmp_path)
+    run_dir = tmp_path / "runs" / "train"
+    weights_dir = run_dir / "weights"
+    weights_dir.mkdir(parents=True)
+    best_path = weights_dir / "best.pt"
+    last_path = weights_dir / "last.pt"
+    best_path.write_bytes(b"best")
+    last_path.write_bytes(b"last")
+    metrics_path = run_dir / "results.csv"
+    metrics_path.write_text("metrics\n", encoding="utf-8")
+    _install_fake_yoloe(
+        monkeypatch,
+        trainer=SimpleNamespace(save_dir=run_dir, best=best_path, last=last_path),
+    )
+
+    export_calls: list[tuple[Path, dict[str, Any]]] = []
+
+    def _fake_export(model_checkpoint: str | Path, **kwargs: Any) -> Path:
+        export_calls.append((Path(model_checkpoint), kwargs))
+        return tmp_path / "artifacts" / "bundle"
+
+    monkeypatch.setattr(export_mod, "export_model", _fake_export)
+
+    result = train_model(
+        "model.pt",
+        dataset_path,
+        export_artifact=True,
+        export_checkpoint="best",
+        export_artifact_dir=tmp_path / "exports",
+        export_formats="onnx",
+        export_dynamic=False,
+        export_build_visual_engine=False,
+        export_fp16=False,
+        export_imgsz=320,
+        export_max_det=17,
+        export_overwrite=False,
+        export_workspace_bytes=1234,
+        export_onnx_exporter="legacy",
+        export_onnx_opset_version=17,
+    )
+
+    assert result.exported_checkpoint_path == best_path.resolve()
+    assert result.artifact_dir == tmp_path / "artifacts" / "bundle"
+    assert export_calls == [
+        (
+            best_path.resolve(),
+            {
+                "artifact_dir": tmp_path / "exports",
+                "formats": "onnx",
+                "dynamic": False,
+                "build_visual_engine": False,
+                "fp16": False,
+                "imgsz": 320,
+                "max_det": 17,
+                "overwrite": False,
+                "workspace_bytes": 1234,
+                "onnx_exporter": "legacy",
+                "onnx_opset_version": 17,
+                "training_metadata": {
+                    **result.metadata,
+                    "run_dir": str(run_dir.resolve()),
+                    "metrics_path": str(metrics_path.resolve()),
+                    "checkpoint_path": str(best_path.resolve()),
+                    "best_checkpoint_path": str(best_path.resolve()),
+                    "last_checkpoint_path": str(last_path.resolve()),
+                    "export_checkpoint": "best",
+                    "exported_checkpoint_path": str(best_path.resolve()),
+                },
+            },
+        )
+    ]
+
+
+def test_train_model_can_export_last_checkpoint_even_when_best_exists(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    dataset_path = _make_dataset_config(tmp_path)
+    run_dir = tmp_path / "runs" / "train"
+    weights_dir = run_dir / "weights"
+    weights_dir.mkdir(parents=True)
+    best_path = weights_dir / "best.pt"
+    last_path = weights_dir / "last.pt"
+    best_path.write_bytes(b"best")
+    last_path.write_bytes(b"last")
+    _install_fake_yoloe(
+        monkeypatch,
+        trainer=SimpleNamespace(save_dir=run_dir, best=best_path, last=last_path),
+    )
+
+    exported: list[Path] = []
+    monkeypatch.setattr(
+        export_mod,
+        "export_model",
+        lambda model_checkpoint, **_kwargs: exported.append(Path(model_checkpoint)) or (tmp_path / "artifacts"),
+    )
+
+    result = train_model("model.pt", dataset_path, export_artifact=True, export_checkpoint="last")
+
+    assert exported == [last_path.resolve()]
+    assert result.exported_checkpoint_path == last_path.resolve()
+
+
+def test_train_model_raises_when_requested_export_checkpoint_is_missing(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    dataset_path = _make_dataset_config(tmp_path)
+    run_dir = tmp_path / "runs" / "train"
+    weights_dir = run_dir / "weights"
+    weights_dir.mkdir(parents=True)
+    last_path = weights_dir / "last.pt"
+    last_path.write_bytes(b"last")
+    _install_fake_yoloe(
+        monkeypatch,
+        trainer=SimpleNamespace(save_dir=run_dir, best=None, last=last_path),
+    )
+    monkeypatch.setattr(
+        export_mod,
+        "export_model",
+        lambda *_args, **_kwargs: pytest.fail("export_model should not be called when the named checkpoint is missing"),
+    )
+
+    with pytest.raises(TrainingError, match="Could not export the best checkpoint"):
+        train_model("model.pt", dataset_path, export_artifact=True, export_checkpoint="best")
+
+
+def test_train_model_wraps_export_failures(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    dataset_path = _make_dataset_config(tmp_path)
+    run_dir = tmp_path / "runs" / "train"
+    weights_dir = run_dir / "weights"
+    weights_dir.mkdir(parents=True)
+    best_path = weights_dir / "best.pt"
+    best_path.write_bytes(b"best")
+    _install_fake_yoloe(
+        monkeypatch,
+        trainer=SimpleNamespace(save_dir=run_dir, best=best_path, last=None),
+    )
+
+    def _fail_export(*_args: Any, **_kwargs: Any) -> Path:
+        raise RuntimeError("export boom")
+
+    monkeypatch.setattr(export_mod, "export_model", _fail_export)
+
+    with pytest.raises(TrainingError, match="Training succeeded but export failed"):
+        train_model("model.pt", dataset_path, export_artifact=True)
 
 
 @pytest.mark.parametrize("save_value", [False, 0])

--- a/yoloe_tensorrt/artifacts.py
+++ b/yoloe_tensorrt/artifacts.py
@@ -1,9 +1,22 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Mapping
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any
+
+
+def _json_compatible(value: Any) -> Any:
+    if value is None or isinstance(value, str | int | float | bool):
+        return value
+    if isinstance(value, Path):
+        return str(value)
+    if isinstance(value, Mapping):
+        return {str(key): _json_compatible(item) for key, item in value.items()}
+    if isinstance(value, list | tuple | set | frozenset):
+        return [_json_compatible(item) for item in value]
+    return str(value)
 
 
 @dataclass(frozen=True)
@@ -56,6 +69,7 @@ class ArtifactMetadata:
     image_profile: ShapeProfile
     prompt_profile: ShapeProfile
     visual_profile: ShapeProfile | None
+    training_metadata: dict[str, Any] | None = None
 
     def to_dict(self) -> dict[str, Any]:
         data = asdict(self)
@@ -64,6 +78,8 @@ class ArtifactMetadata:
         data["prompt_profile"] = self.prompt_profile.to_dict()
         if self.visual_profile is not None:
             data["visual_profile"] = self.visual_profile.to_dict()
+        if data["training_metadata"] is not None:
+            data["training_metadata"] = _json_compatible(data["training_metadata"])
         return data
 
     @classmethod
@@ -95,6 +111,7 @@ class ArtifactMetadata:
             image_profile=ShapeProfile.from_dict(data["image_profile"]),
             prompt_profile=ShapeProfile.from_dict(data["prompt_profile"]),
             visual_profile=None if data["visual_profile"] is None else ShapeProfile.from_dict(data["visual_profile"]),
+            training_metadata=None if data.get("training_metadata") is None else dict(data["training_metadata"]),
         )
 
 

--- a/yoloe_tensorrt/export.py
+++ b/yoloe_tensorrt/export.py
@@ -4,7 +4,7 @@ import gc
 import inspect
 import shutil
 from pathlib import Path
-from typing import Iterable, Literal
+from typing import Any, Iterable, Literal, Mapping
 
 import torch
 import torch.nn as nn
@@ -183,6 +183,17 @@ def _make_visual_profile(
     )
 
 
+def _normalize_formats(formats: Iterable[str] | str) -> tuple[str, ...]:
+    entries = (formats,) if isinstance(formats, str) else tuple(formats)
+    normalized = tuple(str(entry).lower() for entry in entries)
+    if not normalized:
+        raise ValueError("At least one export format must be requested.")
+    invalid = sorted({entry for entry in normalized if entry not in {"onnx", "engine"}})
+    if invalid:
+        raise ValueError(f"Unsupported export format(s): {', '.join(invalid)}")
+    return normalized
+
+
 def _torch_onnx_export_signature() -> inspect.Signature | None:
     try:
         return inspect.signature(torch.onnx.export)
@@ -358,7 +369,7 @@ def _export_onnx(
 def export_model(
     pt_path: str | Path,
     artifact_dir: str | Path | None = None,
-    formats: Iterable[str] = ("onnx", "engine"),
+    formats: Iterable[str] | str = ("onnx", "engine"),
     dynamic: bool = True,
     build_visual_engine: bool = True,
     fp16: bool = True,
@@ -368,11 +379,12 @@ def export_model(
     workspace_bytes: int = 2 << 30,
     onnx_exporter: OnnxExporterMode = "auto",
     onnx_opset_version: int | None = None,
+    training_metadata: Mapping[str, Any] | None = None,
 ) -> Path:
     model_path = _resolved_model_path(pt_path)
     artifact_root = Path(artifact_dir) if artifact_dir is not None else default_artifact_dir(model_path)
     artifact_root.mkdir(parents=True, exist_ok=True)
-    requested_formats = {fmt.lower() for fmt in formats}
+    requested_formats = set(_normalize_formats(formats))
     main_onnx_path = artifact_root / MAIN_ONNX_FILENAME
     main_engine_path = artifact_root / MAIN_ENGINE_FILENAME
     visual_onnx_path = artifact_root / VISUAL_ONNX_FILENAME
@@ -577,6 +589,7 @@ def export_model(
         image_profile=image_profile,
         prompt_profile=prompt_profile,
         visual_profile=visual_profile if build_visual_engine else None,
+        training_metadata=None if training_metadata is None else dict(training_metadata),
     )
     save_metadata(artifact_root, metadata)
     LOGGER.info("Saved artifact metadata to '%s'", artifact_root / "metadata.json")

--- a/yoloe_tensorrt/train_cli.py
+++ b/yoloe_tensorrt/train_cli.py
@@ -66,6 +66,89 @@ def build_arg_parser() -> argparse.ArgumentParser:
         help="Skip yoloe-tensorrt dataset validation before launching Ultralytics.",
     )
     parser.set_defaults(validate_dataset=True)
+    export_group = parser.add_argument_group("Export After Training")
+    export_group.add_argument(
+        "--export",
+        action="store_true",
+        help="Export the selected trained checkpoint into a yoloe-tensorrt artifact bundle after training.",
+    )
+    export_group.add_argument(
+        "--export-checkpoint",
+        choices=("best", "last"),
+        default=None,
+        help="Which trained checkpoint to export. Defaults to best when --export is enabled.",
+    )
+    export_group.add_argument(
+        "--export-artifact-dir",
+        default=None,
+        help="Artifact bundle output directory. Defaults to the standard export_model(...) location.",
+    )
+    export_group.add_argument(
+        "--export-format",
+        action="append",
+        dest="export_formats",
+        choices=("onnx", "engine"),
+        default=None,
+        help="Artifact format to generate after training. Repeat to request multiple formats. Defaults to both.",
+    )
+    export_group.add_argument(
+        "--export-dynamic",
+        action="store_true",
+        dest="export_dynamic",
+        help="Enable dynamic image shapes for post-training export.",
+    )
+    export_group.add_argument(
+        "--export-fixed",
+        action="store_false",
+        dest="export_dynamic",
+        help="Disable dynamic image shapes for post-training export.",
+    )
+    parser.set_defaults(export_dynamic=None)
+    export_group.add_argument(
+        "--export-no-visual-engine",
+        action="store_true",
+        help="Skip the visual-prompt TensorRT engine build during post-training export.",
+    )
+    export_group.add_argument(
+        "--export-no-fp16",
+        action="store_true",
+        help="Disable FP16 TensorRT builds during post-training export.",
+    )
+    export_group.add_argument(
+        "--export-imgsz",
+        type=lambda value: _parse_positive_int(value, "--export-imgsz"),
+        default=None,
+        help="Export image size. Defaults to the export_model(...) behavior when omitted.",
+    )
+    export_group.add_argument(
+        "--export-max-det",
+        type=lambda value: _parse_positive_int(value, "--export-max-det"),
+        default=None,
+        help="Maximum detections baked into export metadata. Defaults to 300.",
+    )
+    export_group.add_argument(
+        "--export-workspace-mb",
+        type=lambda value: _parse_positive_int(value, "--export-workspace-mb"),
+        default=None,
+        help="TensorRT builder workspace in MiB for post-training export. Defaults to 2048.",
+    )
+    export_group.add_argument(
+        "--export-exporter",
+        choices=("auto", "legacy", "dynamo"),
+        default=None,
+        help="ONNX exporter backend for post-training export. Defaults to auto.",
+    )
+    export_group.add_argument(
+        "--export-opset-version",
+        type=lambda value: _parse_positive_int(value, "--export-opset-version"),
+        default=None,
+        help="Override the ONNX opset version used for post-training export.",
+    )
+    export_group.add_argument(
+        "--export-overwrite",
+        action="store_true",
+        help="Overwrite existing artifacts during post-training export.",
+    )
     parser.add_argument("--log-level", default="INFO", help="Logging level for the training command.")
     return parser
 
@@ -83,23 +166,47 @@ def main(argv: list[str] | None = None) -> int:
             if "resume" in overrides:
                 raise _CliArgumentError("--resume cannot be combined with --ultralytics-arg resume=...")
             overrides["resume"] = args.resume_checkpoint if args.resume_checkpoint is not None else True
+        if _has_export_options(args) and not args.export:
+            raise _CliArgumentError("--export must be provided when using --export-* options.")
     except _CliArgumentError as exc:
         parser.error(str(exc))
+
+    train_kwargs: dict[str, Any] = {
+        "task": args.task,
+        "imgsz": args.imgsz,
+        "epochs": int(args.epochs),
+        "batch": args.batch,
+        "device": args.device,
+        "output_dir": Path(args.output_dir),
+        "name": args.name,
+        "overrides": overrides,
+        "validate_dataset": bool(args.validate_dataset),
+        "exist_ok": bool(args.exist_ok),
+    }
+    if args.export:
+        train_kwargs.update(
+            export_artifact=True,
+            export_checkpoint=str(args.export_checkpoint or "best"),
+            export_artifact_dir=None if args.export_artifact_dir is None else Path(args.export_artifact_dir),
+            export_formats=tuple(args.export_formats or ("onnx", "engine")),
+            export_dynamic=True if args.export_dynamic is None else bool(args.export_dynamic),
+            export_build_visual_engine=not args.export_no_visual_engine,
+            export_fp16=not args.export_no_fp16,
+            export_imgsz=None if args.export_imgsz is None else int(args.export_imgsz),
+            export_max_det=300 if args.export_max_det is None else int(args.export_max_det),
+            export_overwrite=bool(args.export_overwrite),
+            export_workspace_bytes=(
+                (2048 if args.export_workspace_mb is None else int(args.export_workspace_mb)) << 20
+            ),
+            export_onnx_exporter=str(args.export_exporter or "auto"),
+            export_onnx_opset_version=None if args.export_opset_version is None else int(args.export_opset_version),
+        )
 
     try:
         result = train_model(
             args.model,
             Path(args.data),
-            task=args.task,
-            imgsz=args.imgsz,
-            epochs=int(args.epochs),
-            batch=args.batch,
-            device=args.device,
-            output_dir=Path(args.output_dir),
-            name=args.name,
-            overrides=overrides,
-            validate_dataset=bool(args.validate_dataset),
-            exist_ok=bool(args.exist_ok),
+            **train_kwargs,
         )
     except ImportError as exc:
         print(
@@ -123,6 +230,25 @@ def _parse_batch(value: str) -> int | float | str:
     if not isinstance(parsed, int | float | str):
         raise argparse.ArgumentTypeError("--batch must be an integer, float, or string such as auto.")
     return parsed
+
+
+def _has_export_options(args: argparse.Namespace) -> bool:
+    return any(
+        (
+            args.export_checkpoint is not None,
+            args.export_artifact_dir is not None,
+            bool(args.export_formats),
+            args.export_dynamic is not None,
+            bool(args.export_no_visual_engine),
+            bool(args.export_no_fp16),
+            args.export_imgsz is not None,
+            args.export_max_det is not None,
+            args.export_workspace_mb is not None,
+            args.export_exporter is not None,
+            args.export_opset_version is not None,
+            bool(args.export_overwrite),
+        )
+    )
 
 
 def _parse_imgsz(value: str) -> int | tuple[int, int]:
@@ -181,6 +307,10 @@ def _print_result(result: TrainingResult) -> None:
     print(f"run_dir: {result.run_dir}")
     if result.metrics_path is not None:
         print(f"metrics: {result.metrics_path}")
+    if result.exported_checkpoint_path is not None:
+        print(f"exported_checkpoint: {result.exported_checkpoint_path}")
+    if result.artifact_dir is not None:
+        print(f"artifact_dir: {result.artifact_dir}")
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/yoloe_tensorrt/training.py
+++ b/yoloe_tensorrt/training.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Mapping
+from typing import Any, Iterable, Literal, Mapping
 
 from .datasets import DatasetConfig, DatasetTask, validate_dataset_config
 
@@ -23,6 +23,9 @@ _CONFLICTING_OVERRIDE_KEYS = frozenset(
 )
 _METRICS_FILENAMES = ("results.csv", "results.json", "metrics.json")
 _SUPPORTED_TRAINING_TASKS = {"detect", "segment"}
+_SUPPORTED_EXPORT_CHECKPOINTS = {"best", "last"}
+ExportCheckpoint = Literal["best", "last"]
+OnnxExporterMode = Literal["auto", "legacy", "dynamo"]
 
 
 class TrainingError(RuntimeError):
@@ -35,6 +38,10 @@ class TrainingResult:
     run_dir: Path
     metrics_path: Path | None
     metadata: dict[str, Any]
+    best_checkpoint_path: Path | None = None
+    last_checkpoint_path: Path | None = None
+    artifact_dir: Path | None = None
+    exported_checkpoint_path: Path | None = None
 
 
 def train_model(
@@ -51,11 +58,26 @@ def train_model(
     overrides: Mapping[str, Any] | None = None,
     validate_dataset: bool = True,
     exist_ok: bool = False,
+    export_artifact: bool = False,
+    export_checkpoint: ExportCheckpoint = "best",
+    export_artifact_dir: str | Path | None = None,
+    export_formats: Iterable[str] | str = ("onnx", "engine"),
+    export_dynamic: bool = True,
+    export_build_visual_engine: bool = True,
+    export_fp16: bool = True,
+    export_imgsz: int | tuple[int, int] | list[int] | None = None,
+    export_max_det: int = 300,
+    export_overwrite: bool = True,
+    export_workspace_bytes: int = 2 << 30,
+    export_onnx_exporter: OnnxExporterMode = "auto",
+    export_onnx_opset_version: int | None = None,
 ) -> TrainingResult:
     """Train or fine-tune a YOLOE checkpoint through Ultralytics and return run artifacts."""
 
     if task not in _SUPPORTED_TRAINING_TASKS:
         raise ValueError(f"Unsupported training task {task!r}; expected 'detect' or 'segment'.")
+    if export_checkpoint not in _SUPPORTED_EXPORT_CHECKPOINTS:
+        raise ValueError(f"Unsupported export checkpoint {export_checkpoint!r}; expected 'best' or 'last'.")
 
     model_path = _normalize_model_checkpoint(model_checkpoint)
     dataset_path = _normalize_dataset_config_path(dataset_config)
@@ -86,7 +108,9 @@ def train_model(
         raise TrainingError("Ultralytics training did not expose a trainer with run artifacts.")
 
     run_dir = _resolve_run_dir(trainer)
-    checkpoint_path = _resolve_checkpoint_path(trainer, run_dir)
+    best_checkpoint_path = _resolve_named_checkpoint_path(trainer, run_dir, "best")
+    last_checkpoint_path = _resolve_named_checkpoint_path(trainer, run_dir, "last")
+    checkpoint_path = _resolve_primary_checkpoint_path(best_checkpoint_path, last_checkpoint_path, run_dir)
     metrics_path = _resolve_metrics_path(run_dir)
     metadata = _build_training_metadata(
         model_checkpoint=model_path,
@@ -103,12 +127,57 @@ def train_model(
         overrides=trainer_overrides,
         metrics=metrics,
     )
+    artifact_dir: Path | None = None
+    exported_checkpoint_path: Path | None = None
+
+    if export_artifact:
+        from .export import export_model
+
+        exported_checkpoint_path = _select_export_checkpoint_path(
+            best_checkpoint_path=best_checkpoint_path,
+            last_checkpoint_path=last_checkpoint_path,
+            export_checkpoint=export_checkpoint,
+            run_dir=run_dir,
+        )
+        try:
+            artifact_dir = export_model(
+                exported_checkpoint_path,
+                artifact_dir=None if export_artifact_dir is None else Path(export_artifact_dir).expanduser(),
+                formats=export_formats,
+                dynamic=bool(export_dynamic),
+                build_visual_engine=bool(export_build_visual_engine),
+                fp16=bool(export_fp16),
+                imgsz=export_imgsz,
+                max_det=int(export_max_det),
+                overwrite=bool(export_overwrite),
+                workspace_bytes=int(export_workspace_bytes),
+                onnx_exporter=export_onnx_exporter,
+                onnx_opset_version=None if export_onnx_opset_version is None else int(export_onnx_opset_version),
+                training_metadata=_build_export_training_metadata(
+                    metadata=metadata,
+                    run_dir=run_dir,
+                    metrics_path=metrics_path,
+                    checkpoint_path=checkpoint_path,
+                    best_checkpoint_path=best_checkpoint_path,
+                    last_checkpoint_path=last_checkpoint_path,
+                    export_checkpoint=export_checkpoint,
+                    exported_checkpoint_path=exported_checkpoint_path,
+                ),
+            )
+        except Exception as exc:
+            raise TrainingError(
+                f"Training succeeded but export failed for checkpoint '{exported_checkpoint_path}': {exc}"
+            ) from exc
 
     return TrainingResult(
         checkpoint_path=checkpoint_path,
         run_dir=run_dir,
         metrics_path=metrics_path,
         metadata=metadata,
+        best_checkpoint_path=best_checkpoint_path,
+        last_checkpoint_path=last_checkpoint_path,
+        artifact_dir=artifact_dir,
+        exported_checkpoint_path=exported_checkpoint_path,
     )
 
 
@@ -167,17 +236,47 @@ def _resolve_run_dir(trainer: Any) -> Path:
     return Path(raw_save_dir).expanduser().resolve(strict=False)
 
 
-def _resolve_checkpoint_path(trainer: Any, run_dir: Path) -> Path:
-    for attr in ("best", "last"):
-        path = _optional_path(getattr(trainer, attr, None), base_dir=run_dir)
-        if path is not None and path.exists():
-            return path.resolve()
+def _resolve_named_checkpoint_path(trainer: Any, run_dir: Path, checkpoint_name: ExportCheckpoint) -> Path | None:
+    path = _optional_path(getattr(trainer, checkpoint_name, None), base_dir=run_dir)
+    if path is not None and path.exists():
+        return path.resolve()
 
-    for candidate in (run_dir / "weights" / "best.pt", run_dir / "weights" / "last.pt"):
-        if candidate.exists():
-            return candidate.resolve()
+    candidate = run_dir / "weights" / f"{checkpoint_name}.pt"
+    if candidate.exists():
+        return candidate.resolve()
+    return None
 
+
+def _resolve_primary_checkpoint_path(
+    best_checkpoint_path: Path | None,
+    last_checkpoint_path: Path | None,
+    run_dir: Path,
+) -> Path:
+    if best_checkpoint_path is not None:
+        return best_checkpoint_path
+    if last_checkpoint_path is not None:
+        return last_checkpoint_path
     raise TrainingError(f"Could not find a trained checkpoint under Ultralytics run directory: {run_dir}")
+
+
+def _select_export_checkpoint_path(
+    *,
+    best_checkpoint_path: Path | None,
+    last_checkpoint_path: Path | None,
+    export_checkpoint: ExportCheckpoint,
+    run_dir: Path,
+) -> Path:
+    if export_checkpoint == "best":
+        if best_checkpoint_path is not None:
+            return best_checkpoint_path
+        raise TrainingError(
+            f"Could not export the best checkpoint because '{run_dir / 'weights' / 'best.pt'}' was not found."
+        )
+    if last_checkpoint_path is not None:
+        return last_checkpoint_path
+    raise TrainingError(
+        f"Could not export the last checkpoint because '{run_dir / 'weights' / 'last.pt'}' was not found."
+    )
 
 
 def _resolve_metrics_path(run_dir: Path) -> Path | None:
@@ -228,6 +327,28 @@ def _build_training_metadata(
         "overrides": dict(overrides),
         "metrics_type": None if metrics is None else type(metrics).__name__,
     }
+
+
+def _build_export_training_metadata(
+    *,
+    metadata: Mapping[str, Any],
+    run_dir: Path,
+    metrics_path: Path | None,
+    checkpoint_path: Path,
+    best_checkpoint_path: Path | None,
+    last_checkpoint_path: Path | None,
+    export_checkpoint: ExportCheckpoint,
+    exported_checkpoint_path: Path,
+) -> dict[str, Any]:
+    export_metadata = dict(metadata)
+    export_metadata["run_dir"] = str(run_dir)
+    export_metadata["metrics_path"] = None if metrics_path is None else str(metrics_path)
+    export_metadata["checkpoint_path"] = str(checkpoint_path)
+    export_metadata["best_checkpoint_path"] = None if best_checkpoint_path is None else str(best_checkpoint_path)
+    export_metadata["last_checkpoint_path"] = None if last_checkpoint_path is None else str(last_checkpoint_path)
+    export_metadata["export_checkpoint"] = export_checkpoint
+    export_metadata["exported_checkpoint_path"] = str(exported_checkpoint_path)
+    return export_metadata
 
 
 def _dataset_metadata(dataset: DatasetConfig | None) -> dict[str, Any] | None:


### PR DESCRIPTION
  - Added optional post-training export to train_model(...), with support for exporting either the best or last trained checkpoint through the existing export_model(...) path.
  - Extended TrainingResult with best/last checkpoint paths plus exported artifact information.
  - Added training_metadata support to artifact metadata for traceability from exported bundles back to the training run.
  - Normalized training metadata to JSON-safe values before writing metadata.json.
  - Added yoloe-train --export and --export-* flags for post-training export control, including checkpoint selection, formats, shape mode, FP16, visual engine, exporter, opset, workspace, and artifact directory.
  - Print exported checkpoint and artifact directory from the training CLI when export runs successfully.
  - Added tests for checkpoint selection, export error handling, CLI forwarding/validation, artifact metadata compatibility, and metadata serialization edge cases.
  - Updated training and export docs, docs index, README, and changelog for the integrated training-to-export workflow.